### PR TITLE
Add CLI Version Auto-Fetch & Implement New Subcommands (status, service describe)

### DIFF
--- a/cli/src/general.rs
+++ b/cli/src/general.rs
@@ -7,7 +7,7 @@ pub struct GeneralData {
 }
 
 impl GeneralData {
-    pub const VERSION: &str = "0.1";
+    pub const VERSION: &str = env!("CARGO_PKG_VERSION");
     pub const AUTHOR: &str = "CortexFlow";
     pub const DESCRIPTION: &str = "";
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -3,6 +3,7 @@ mod install;
 mod general;
 mod uninstall;
 mod service;
+mod status;
 
 use clap::{ Error, Parser, Subcommand, Args };
 use clap::command;
@@ -12,6 +13,7 @@ use crate::essential::{ info, update_cli };
 use crate::install::install_cortexflow;
 use crate::uninstall::uninstall;
 use crate::service::{list_services, describe_service};
+use crate::status::status_command;
 
 use crate::general::GeneralData;
 
@@ -46,6 +48,8 @@ enum Commands {
     Info,
     #[command(name="service")]
     Service(ServiceArgs),
+    #[command(name="status")]
+    Status(StatusArgs),
 }
 #[derive(Args, Debug, Clone)]
 struct SetArgs {
@@ -71,6 +75,12 @@ enum ServiceCommands {
         #[arg(long)]
         namespace: Option<String>,
     },
+}
+
+#[derive(Args, Debug, Clone)]
+struct StatusArgs {
+    #[arg(long, value_enum)]
+    output: Option<String>,
 }
 
 fn args_parser() -> Result<(), Error> {
@@ -114,6 +124,10 @@ fn args_parser() -> Result<(), Error> {
                     Ok(())
                 }
             }
+        }
+        Some(Commands::Status(status_args)) => {
+            status_command(status_args.output);
+            Ok(())
         }
         None => {
             eprintln!("CLI unknown argument. Cli arguments passed: {:?}", args.cmd);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -79,8 +79,10 @@ enum ServiceCommands {
 
 #[derive(Args, Debug, Clone)]
 struct StatusArgs {
-    #[arg(long, value_enum)]
+    #[arg(long)]
     output: Option<String>,
+    #[arg(long)]
+    namespace: Option<String>,
 }
 
 fn args_parser() -> Result<(), Error> {
@@ -126,7 +128,7 @@ fn args_parser() -> Result<(), Error> {
             }
         }
         Some(Commands::Status(status_args)) => {
-            status_command(status_args.output);
+            status_command(status_args.output, status_args.namespace);
             Ok(())
         }
         None => {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -11,7 +11,7 @@ use tracing::debug;
 use crate::essential::{ info, update_cli };
 use crate::install::install_cortexflow;
 use crate::uninstall::uninstall;
-use crate::service::list_services;
+use crate::service::{list_services, describe_service};
 
 use crate::general::GeneralData;
 
@@ -65,6 +65,12 @@ enum ServiceCommands {
         #[arg(long)]
         namespace: Option<String>,
     },
+    #[command(name="describe")]
+    Describe {
+        service_name: String,
+        #[arg(long)]
+        namespace: Option<String>,
+    },
 }
 
 fn args_parser() -> Result<(), Error> {
@@ -101,6 +107,10 @@ fn args_parser() -> Result<(), Error> {
             match service_args.service_cmd {
                 ServiceCommands::List { namespace } => {
                     list_services(namespace);
+                    Ok(())
+                }
+                ServiceCommands::Describe { service_name, namespace } => {
+                    describe_service(service_name, namespace);
                     Ok(())
                 }
             }

--- a/cli/src/mod.rs
+++ b/cli/src/mod.rs
@@ -3,3 +3,4 @@ pub mod install;
 pub mod general;
 pub mod uninstall;
 pub mod service;
+pub mod status;

--- a/cli/src/status.rs
+++ b/cli/src/status.rs
@@ -1,0 +1,190 @@
+use std::process::Command;
+use std::str;
+
+#[derive(Debug)]
+pub enum OutputFormat {
+    Text,
+    Json,
+    Yaml,
+}
+
+impl From<String> for OutputFormat {
+    fn from(s: String) -> Self {
+        match s.to_lowercase().as_str() {
+            "json" => OutputFormat::Json,
+            "yaml" => OutputFormat::Yaml,
+            _ => OutputFormat::Text,
+        }
+    }
+}
+
+pub fn status_command(output_format: Option<String>) {
+    let format = output_format.map(OutputFormat::from).unwrap_or(OutputFormat::Text);
+    
+    println!("Checking CortexFlow status...");
+    
+    // namespace checking
+    let namespace_status = check_namespace_exists("cortexflow");
+    
+    // get pods
+    let pods_status = get_pods_status("cortexflow");
+    
+    // get services
+    let services_status = get_services_status("cortexflow");
+    
+    // display options (format)
+    match format {
+        OutputFormat::Text => display_text_format(namespace_status, pods_status, services_status),
+        OutputFormat::Json => display_json_format(namespace_status, pods_status, services_status),
+        OutputFormat::Yaml => display_yaml_format(namespace_status, pods_status, services_status),
+    }
+}
+
+fn check_namespace_exists(namespace: &str) -> bool {
+    let output = Command::new("kubectl")
+        .args(["get", "namespace", namespace])
+        .output();
+    
+    match output {
+        Ok(output) => output.status.success(),
+        Err(_) => false,
+    }
+}
+
+fn get_pods_status(namespace: &str) -> Vec<(String, String, String)> {
+    let output = Command::new("kubectl")
+        .args(["get", "pods", "-n", namespace, "--no-headers"])
+        .output();
+    
+    match output {
+        Ok(output) if output.status.success() => {
+            let stdout = str::from_utf8(&output.stdout).unwrap_or("");
+            stdout.lines()
+                .filter_map(|line| {
+                    let parts: Vec<&str> = line.split_whitespace().collect();
+                    if parts.len() >= 3 {
+                        Some((
+                            parts[0].to_string(),  // name
+                            parts[1].to_string(),  // ready
+                            parts[2].to_string(),  // status
+                        ))
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn get_services_status(namespace: &str) -> Vec<(String, String, String)> {
+    let output = Command::new("kubectl")
+        .args(["get", "services", "-n", namespace, "--no-headers"])
+        .output();
+    
+    match output {
+        Ok(output) if output.status.success() => {
+            let stdout = str::from_utf8(&output.stdout).unwrap_or("");
+            stdout.lines()
+                .filter_map(|line| {
+                    let parts: Vec<&str> = line.split_whitespace().collect();
+                    if parts.len() >= 4 {
+                        Some((
+                            parts[0].to_string(),  // name
+                            parts[1].to_string(),  // type
+                            parts[2].to_string(),  // cluster ips
+                        ))
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn display_text_format(namespace_exists: bool, pods: Vec<(String, String, String)>, services: Vec<(String, String, String)>) {
+    println!("\n🔍 CortexFlow Status Report");
+    println!("{}", "=".repeat(50));
+    
+    println!("\n📦 Namespace Status:");
+    if namespace_exists {
+        println!("  ✅ cortexflow namespace: EXISTS");
+    } else {
+        println!("  ❌ cortexflow namespace: NOT FOUND");
+    }
+    
+    println!("\n🚀 Pods Status:");
+    if pods.is_empty() {
+        println!("  ⚠️  No pods found in cortexflow namespace");
+    } else {
+        for (name, ready, status) in pods {
+            let icon = if status == "Running" { "✅" } else { "⚠️" };
+            println!("  {} {}: {} ({})", icon, name, status, ready);
+        }
+    }
+    
+    println!("\n🌐 Services Status:");
+    if services.is_empty() {
+        println!("  ⚠️  No services found in cortexflow namespace");
+    } else {
+        for (name, service_type, cluster_ip) in services {
+            println!("  🔗 {}: {} ({})", name, service_type, cluster_ip);
+        }
+    }
+    
+    println!("\n{}", "=".repeat(50));
+}
+
+fn display_json_format(namespace_exists: bool, pods: Vec<(String, String, String)>, services: Vec<(String, String, String)>) {
+    println!("{{");
+    println!("  \"namespace\": {{");
+    println!("    \"name\": \"cortexflow\",");
+    println!("    \"exists\": {}", namespace_exists);
+    println!("  }},");
+    
+    println!("  \"pods\": [");
+    for (i, (name, ready, status)) in pods.iter().enumerate() {
+        let comma = if i == pods.len() - 1 { "" } else { "," };
+        println!("    {{");
+        println!("      \"name\": \"{}\",", name);
+        println!("      \"ready\": \"{}\",", ready);
+        println!("      \"status\": \"{}\"", status);
+        println!("    }}{}", comma);
+    }
+    println!("  ],");
+    
+    println!("  \"services\": [");
+    for (i, (name, service_type, cluster_ip)) in services.iter().enumerate() {
+        let comma = if i == services.len() - 1 { "" } else { "," };
+        println!("    {{");
+        println!("      \"name\": \"{}\",", name);
+        println!("      \"type\": \"{}\",", service_type);
+        println!("      \"cluster_ip\": \"{}\"", cluster_ip);
+        println!("    }}{}", comma);
+    }
+    println!("  ]");
+    println!("}}");
+}
+
+fn display_yaml_format(namespace_exists: bool, pods: Vec<(String, String, String)>, services: Vec<(String, String, String)>) {
+    println!("namespace:");
+    println!("  name: cortexflow");
+    println!("  exists: {}", namespace_exists);
+    
+    println!("pods:");
+    for (name, ready, status) in pods {
+        println!("  - name: {}", name);
+        println!("    ready: {}", ready);
+        println!("    status: {}", status);
+    }
+    
+    println!("services:");
+    for (name, service_type, cluster_ip) in services {
+        println!("  - name: {}", name);
+        println!("    type: {}", service_type);
+        println!("    cluster_ip: {}", cluster_ip);
+    }
+}


### PR DESCRIPTION
This PR introduces multiple enhancements to the CortexBrain CLI tool:

- Auto-fetch CLI version directly from `Cargo.toml`, eliminating manual versioning. (6e061eea167a5ceaf6f313da905a1cca695ef1d0)

- Added `status` command: Displays namespace info, running pods, and running services. (640800e21f7e13f98153819c3ae57608d8a6cd1b)

- Added `service describe` subcommand: Provides detailed overview of a running service. (a9186da61e6b9af03a5a451017443649566c8ab4)

Linked to: [#77]