### PR TITLE
Added `logs` command and integrated it into the CLI structure.

### DIFF
--- a/cli/src/logs.rs
+++ b/cli/src/logs.rs
@@ -1,0 +1,196 @@
+use std::process::Command;
+use std::str;
+
+#[derive(Debug, Clone)]
+pub enum Component {
+    ControlPlane,
+    DataPlane,
+}
+
+impl From<String> for Component {
+    fn from(s: String) -> Self {
+        match s.to_lowercase().as_str() {
+            "control-plane" => Component::ControlPlane,
+            "data-plane" => Component::DataPlane,
+            //default will be control plane.
+            _ => Component::ControlPlane,
+        }
+    }
+}
+
+impl Component {
+    fn to_label_selector(&self) -> &str {
+        match self {
+            Component::ControlPlane => "component=control-plane",
+            Component::DataPlane => "component=data-plane",
+        }
+    }
+}
+
+fn check_namespace_exists(namespace: &str) -> bool {
+    let output = Command::new("kubectl")
+        .args(["get", "namespace", namespace])
+        .output();
+    
+    match output {
+        Ok(output) => output.status.success(),
+        Err(_) => false,
+    }
+}
+
+fn get_available_namespaces() -> Vec<String> {
+    let output = Command::new("kubectl")
+        .args(["get", "namespaces", "--no-headers", "-o", "custom-columns=NAME:.metadata.name"])
+        .output();
+    
+    match output {
+        Ok(output) if output.status.success() => {
+            let stdout = str::from_utf8(&output.stdout).unwrap_or("");
+            stdout.lines()
+                .map(|line| line.trim().to_string())
+                .filter(|line| !line.is_empty())
+                .collect()
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn get_pods_for_service(namespace: &str, service_name: &str) -> Vec<String> {
+    let output = Command::new("kubectl")
+        .args(["get", "pods", "-n", namespace, "-l", &format!("app={}", service_name), "--no-headers", "-o", "custom-columns=NAME:.metadata.name"])
+        .output();
+    
+    match output {
+        Ok(output) if output.status.success() => {
+            let stdout = str::from_utf8(&output.stdout).unwrap_or("");
+            stdout.lines()
+                .map(|line| line.trim().to_string())
+                .filter(|line| !line.is_empty())
+                .collect()
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn get_pods_for_component(namespace: &str, component: &Component) -> Vec<String> {
+    let output = Command::new("kubectl")
+        .args(["get", "pods", "-n", namespace, "-l", component.to_label_selector(), "--no-headers", "-o", "custom-columns=NAME:.metadata.name"])
+        .output();
+    
+    match output {
+        Ok(output) if output.status.success() => {
+            let stdout = str::from_utf8(&output.stdout).unwrap_or("");
+            stdout.lines()
+                .map(|line| line.trim().to_string())
+                .filter(|line| !line.is_empty())
+                .collect()
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn get_all_pods(namespace: &str) -> Vec<String> {
+    let output = Command::new("kubectl")
+        .args(["get", "pods", "-n", namespace, "--no-headers", "-o", "custom-columns=NAME:.metadata.name"])
+        .output();
+    
+    match output {
+        Ok(output) if output.status.success() => {
+            let stdout = str::from_utf8(&output.stdout).unwrap_or("");
+            stdout.lines()
+                .map(|line| line.trim().to_string())
+                .filter(|line| !line.is_empty())
+                .collect()
+        }
+        _ => Vec::new(),
+    }
+}
+
+pub fn logs_command(service: Option<String>, component: Option<String>, namespace: Option<String>) {
+    let ns = namespace.unwrap_or_else(|| "cortexflow".to_string());
+    
+    // namespace check
+    if !check_namespace_exists(&ns) {
+        let available_namespaces = get_available_namespaces();
+        
+        println!("\n❌ Namespace '{}' not found", ns);
+        println!("{}", "=".repeat(50));
+        
+        if !available_namespaces.is_empty() {
+            println!("\n📋 Available namespaces:");
+            for available_ns in &available_namespaces {
+                println!("  • {}", available_ns);
+            }
+        } else {
+            println!("No namespaces found in the cluster.");
+        }
+        
+        std::process::exit(1);
+    }
+    
+    // determine pods.
+    let pods = match (service, component) {
+        (Some(service_name), Some(component_str)) => {
+            let comp = Component::from(component_str);
+            println!("Getting logs for service '{}' with component '{:?}' in namespace '{}'", service_name, comp, ns);
+            
+            let service_pods = get_pods_for_service(&ns, &service_name);
+            let component_pods = get_pods_for_component(&ns, &comp);
+            
+            // intersection
+            service_pods.into_iter()
+                .filter(|pod| component_pods.contains(pod))
+                .collect()
+        }
+        (Some(service_name), None) => {
+            //only service
+            println!("Getting logs for service '{}' in namespace '{}'", service_name, ns);
+            get_pods_for_service(&ns, &service_name)
+        }
+        (None, Some(component_str)) => {
+            //only component
+            let comp = Component::from(component_str);
+            println!("Getting logs for component '{:?}' in namespace '{}'", comp, ns);
+            get_pods_for_component(&ns, &comp)
+        }
+        (None, None) => {
+            //neither, get all
+            println!("Getting logs for all pods in namespace '{}'", ns);
+            get_all_pods(&ns)
+        }
+    };
+    
+    if pods.is_empty() {
+        println!("No pods found matching the specified criteria");
+        return;
+    }
+
+    for pod in pods {
+        println!("\n{}", "=".repeat(80));
+        println!("📋 Logs for pod: {}", pod);
+        println!("{}", "=".repeat(80));
+        
+        let output = Command::new("kubectl")
+            .args(["logs", &pod, "-n", &ns, "--tail=50"])
+            .output();
+        
+        match output {
+            Ok(output) => {
+                if output.status.success() {
+                    let stdout = str::from_utf8(&output.stdout).unwrap_or("");
+                    if stdout.trim().is_empty() {
+                        println!("No logs available for pod '{}'", pod);
+                    } else {
+                        println!("{}", stdout);
+                    }
+                } else {
+                    let stderr = str::from_utf8(&output.stderr).unwrap_or("Unknown error");
+                    eprintln!("Error getting logs for pod '{}': {}", pod, stderr);
+                }
+            }
+            Err(err) => {
+                eprintln!("Failed to execute kubectl logs for pod '{}': {}", pod, err);
+            }
+        }
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4,6 +4,7 @@ mod general;
 mod uninstall;
 mod service;
 mod status;
+mod logs;
 
 use clap::{ Error, Parser, Subcommand, Args };
 use clap::command;
@@ -14,6 +15,7 @@ use crate::install::install_cortexflow;
 use crate::uninstall::uninstall;
 use crate::service::{list_services, describe_service};
 use crate::status::status_command;
+use crate::logs::logs_command;
 
 use crate::general::GeneralData;
 
@@ -50,6 +52,8 @@ enum Commands {
     Service(ServiceArgs),
     #[command(name="status")]
     Status(StatusArgs),
+    #[command(name="logs")]
+    Logs(LogsArgs),
 }
 #[derive(Args, Debug, Clone)]
 struct SetArgs {
@@ -81,6 +85,16 @@ enum ServiceCommands {
 struct StatusArgs {
     #[arg(long)]
     output: Option<String>,
+    #[arg(long)]
+    namespace: Option<String>,
+}
+
+#[derive(Args, Debug, Clone)]
+struct LogsArgs {
+    #[arg(long)]
+    service: Option<String>,
+    #[arg(long)]
+    component: Option<String>,
     #[arg(long)]
     namespace: Option<String>,
 }
@@ -129,6 +143,10 @@ fn args_parser() -> Result<(), Error> {
         }
         Some(Commands::Status(status_args)) => {
             status_command(status_args.output, status_args.namespace);
+            Ok(())
+        }
+        Some(Commands::Logs(logs_args)) => {
+            logs_command(logs_args.service, logs_args.component, logs_args.namespace);
             Ok(())
         }
         None => {

--- a/cli/src/mod.rs
+++ b/cli/src/mod.rs
@@ -4,3 +4,4 @@ pub mod general;
 pub mod uninstall;
 pub mod service;
 pub mod status;
+pub mod logs;


### PR DESCRIPTION
This pull request adds a new `logs` feature to the CLI tool, allowing users to get logs for specific services, components, or all pods in a namespace. The updates involve adding logic to interact with Kubernetes using `kubectl` commands and incorporating the new feature into the CLI framework.

### New `logs` feature implementation:

* **`cli/src/logs.rs`:** A detailed implementation for the `logs_command` function was added, which retrieves logs through `kubectl`. It features helper functions for validating namespaces, retrieving pods based on service or component labels, and fetching logs for individual pods. A new `Component` enum was created to represent control-plane and data-plane components.

### Integration into CLI framework:

* **`cli/src/main.rs`:** 
  - The new `logs` module and command were registered in the CLI structure.
  - A `LogsArgs` struct was added to define arguments for the `logs` command, including `service`, `component`, and `namespace`.
  - The `logs_command` function was integrated into the CLI argument parser, allowing the execution of the `logs` command.
  - Imports were updated to include the `logs` module and its related command.

These updates improve the functionality of the CLI tool by giving users the ability to retrieve detailed logs directly from their Kubernetes cluster.