### PR TITLE
Feature/ebpf core

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -54,6 +54,7 @@ dependencies = [
  "tonic-prost-build",
  "tonic-reflection",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/core/src/components/metrics/src/helpers.rs
+++ b/core/src/components/metrics/src/helpers.rs
@@ -1,0 +1,54 @@
+use aya::{
+    maps::{
+        MapData,
+        perf::{PerfEventArrayBuffer},
+    }
+};
+
+use bytes::BytesMut;
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+    },
+};
+
+use tracing::{error, info};
+
+use crate::structs::NetworkMetrics;
+
+pub async fn display_metrics_map(
+    mut perf_buffers: Vec<PerfEventArrayBuffer<MapData>>,
+    running: AtomicBool,
+    mut buffers: Vec<BytesMut>,
+) {
+    while running.load(Ordering::SeqCst) {
+        for buf in perf_buffers.iter_mut() {
+            match buf.read_events(&mut buffers) {
+                std::result::Result::Ok(events) => {
+                    for i in 0..events.read {
+                        let data = &buffers[i];
+                        if data.len() >= std::mem::size_of::<NetworkMetrics>() {
+                            let net_metrics: NetworkMetrics =
+                                unsafe { std::ptr::read_unaligned(data.as_ptr() as *const _) };
+                            let sk_drop_count = net_metrics.sk_drops;
+                            let sk_err = net_metrics.sk_err;
+                            let sk_err_soft = net_metrics.sk_err_soft;
+                            let sk_backlog_len = net_metrics.sk_backlog_len;
+                            let sk_write_memory_queued = net_metrics.sk_write_memory_queued;
+                            let sk_ack_backlog = net_metrics.sk_ack_backlog;
+                            let sk_receive_buffer_size = net_metrics.sk_receive_buffer_size;
+                            info!(
+                                "sk_drops: {}, sk_err: {}, sk_err_soft: {}, sk_backlog_len: {}, sk_write_memory_queued: {}, sk_ack_backlog: {}, sk_receive_buffer_size: {}",
+                                sk_drop_count, sk_err, sk_err_soft, sk_backlog_len, sk_write_memory_queued, sk_ack_backlog, sk_receive_buffer_size
+                            );
+                        }
+                    }
+                }
+                Err(e) => {
+                    error!("Error reading events: {:?}", e);
+                }
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+}

--- a/core/src/components/metrics/src/main.rs
+++ b/core/src/components/metrics/src/main.rs
@@ -14,7 +14,7 @@ use std::{
     env, fs,
     path::Path,
     sync::{
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool},
     },
 };
 
@@ -25,8 +25,10 @@ use tracing_subscriber::{EnvFilter, fmt::format::FmtSpan};
 
 const BPF_PATH: &str = "BPF_PATH"; //BPF env path
 
+mod helpers;
+use crate::helpers::display_metrics_map;
+
 mod structs;
-use crate::structs::NetworkMetrics;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
@@ -90,44 +92,6 @@ async fn main() -> Result<(), anyhow::Error> {
         display_metrics_map(net_perf_buffer, running, buffers).await;
     });
 
-
     signal::ctrl_c().await?;
     Ok(())
-}
-
-pub async fn display_metrics_map(
-    mut perf_buffers: Vec<PerfEventArrayBuffer<MapData>>,
-    running: AtomicBool,
-    mut buffers: Vec<BytesMut>,
-) {
-    while running.load(Ordering::SeqCst) {
-        for buf in perf_buffers.iter_mut() {
-            match buf.read_events(&mut buffers) {
-                std::result::Result::Ok(events) => {
-                    for i in 0..events.read {
-                        let data = &buffers[i];
-                        if data.len() >= std::mem::size_of::<NetworkMetrics>() {
-                            let net_metrics: NetworkMetrics =
-                                unsafe { std::ptr::read_unaligned(data.as_ptr() as *const _) };
-                            let sk_drop_count = net_metrics.sk_drops;
-                            let sk_err = net_metrics.sk_err;
-                            let sk_err_soft = net_metrics.sk_err_soft;
-                            let sk_backlog_len = net_metrics.sk_backlog_len;
-                            let sk_write_memory_queued = net_metrics.sk_write_memory_queued;
-                            let sk_ack_backlog = net_metrics.sk_ack_backlog;
-                            let sk_receive_buffer_size = net_metrics.sk_receive_buffer_size;
-                            info!(
-                                "sk_drops: {}, sk_err: {}, sk_err_soft: {}, sk_backlog_len: {}, sk_write_memory_queued: {}, sk_ack_backlog: {}, sk_receive_buffer_size: {}",
-                                sk_drop_count, sk_err, sk_err_soft, sk_backlog_len, sk_write_memory_queued, sk_ack_backlog, sk_receive_buffer_size
-                            );
-                        }
-                    }
-                }
-                Err(e) => {
-                    error!("Error reading events: {:?}", e);
-                }
-            }
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-    }
 }

--- a/core/src/components/metrics/src/main.rs
+++ b/core/src/components/metrics/src/main.rs
@@ -113,12 +113,12 @@ pub async fn display_metrics_map(
                             let sk_err = net_metrics.sk_err;
                             let sk_err_soft = net_metrics.sk_err_soft;
                             let sk_backlog_len = net_metrics.sk_backlog_len;
-                            let sk_wmem_queued = net_metrics.sk_wmem_queued;
+                            let sk_write_memory_queued = net_metrics.sk_write_memory_queued;
                             let sk_ack_backlog = net_metrics.sk_ack_backlog;
-                            let sk_rcvbuf = net_metrics.sk_rcvbuf;
+                            let sk_receive_buffer_size = net_metrics.sk_receive_buffer_size;
                             info!(
-                                "sk_drops: {}, sk_err: {}, sk_err_soft: {}, sk_backlog_len: {}, sk_wmem_queued: {}, sk_ack_backlog: {}, sk_rcvbuf: {}",
-                                sk_drop_count, sk_err, sk_err_soft, sk_backlog_len, sk_wmem_queued, sk_ack_backlog, sk_rcvbuf
+                                "sk_drops: {}, sk_err: {}, sk_err_soft: {}, sk_backlog_len: {}, sk_write_memory_queued: {}, sk_ack_backlog: {}, sk_receive_buffer_size: {}",
+                                sk_drop_count, sk_err, sk_err_soft, sk_backlog_len, sk_write_memory_queued, sk_ack_backlog, sk_receive_buffer_size
                             );
                         }
                     }

--- a/core/src/components/metrics/src/mod.rs
+++ b/core/src/components/metrics/src/mod.rs
@@ -1,0 +1,3 @@
+mod structs;
+mod enums;
+mod helpers;

--- a/core/src/components/metrics/src/structs.rs
+++ b/core/src/components/metrics/src/structs.rs
@@ -6,8 +6,8 @@ pub struct NetworkMetrics {
     pub sk_err: i32,          // Offset 284
     pub sk_err_soft: i32,     // Offset 600
     pub sk_backlog_len: i32,  // Offset 196
-    pub sk_wmem_queued: i32,  // Offset 376
-    pub sk_rcvbuf: i32,       // Offset 244
+    pub sk_write_memory_queued: i32,  // Offset 376
+    pub sk_receive_buffer_size: i32,       // Offset 244
     pub sk_ack_backlog: u32,  // Offset 604
     pub sk_drops: i32,        // Offset 136
 }

--- a/core/src/components/metrics/src/structs.rs
+++ b/core/src/components/metrics/src/structs.rs
@@ -1,0 +1,13 @@
+
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct NetworkMetrics {
+    pub sk_err: i32,          // Offset 284
+    pub sk_err_soft: i32,     // Offset 600
+    pub sk_backlog_len: i32,  // Offset 196
+    pub sk_wmem_queued: i32,  // Offset 376
+    pub sk_rcvbuf: i32,       // Offset 244
+    pub sk_ack_backlog: u32,  // Offset 604
+    pub sk_drops: i32,        // Offset 136
+}

--- a/core/src/components/metrics_tracer/src/data_structures.rs
+++ b/core/src/components/metrics_tracer/src/data_structures.rs
@@ -1,0 +1,15 @@
+use aya_ebpf::{macros::map, maps::{LruPerCpuHashMap, PerfEventArray}};
+
+
+pub struct NetworkMetrics {
+    pub sk_err: i32,          // Offset 284
+    pub sk_err_soft: i32,     // Offset 600
+    pub sk_backlog_len: i32,  // Offset 196
+    pub sk_wmem_queued: i32,  // Offset 376
+    pub sk_rcvbuf: i32,       // Offset 244
+    pub sk_ack_backlog: u32,  // Offset 604
+    pub sk_drops: i32,        // Offset 136
+}
+
+#[map(name = "net_metrics")]
+pub static NET_METRICS: PerfEventArray<NetworkMetrics> = PerfEventArray::new(0);

--- a/core/src/components/metrics_tracer/src/data_structures.rs
+++ b/core/src/components/metrics_tracer/src/data_structures.rs
@@ -2,13 +2,13 @@ use aya_ebpf::{macros::map, maps::{LruPerCpuHashMap, PerfEventArray}};
 
 
 pub struct NetworkMetrics {
-    pub sk_err: i32,          // Offset 284
-    pub sk_err_soft: i32,     // Offset 600
-    pub sk_backlog_len: i32,  // Offset 196
-    pub sk_wmem_queued: i32,  // Offset 376
-    pub sk_rcvbuf: i32,       // Offset 244
-    pub sk_ack_backlog: u32,  // Offset 604
-    pub sk_drops: i32,        // Offset 136
+    pub sk_err: i32,                // Offset 284
+    pub sk_err_soft: i32,           // Offset 600
+    pub sk_backlog_len: i32,        // Offset 196
+    pub sk_write_memory_queued: i32,// Offset 376
+    pub sk_receive_buffer_size: i32,// Offset 244
+    pub sk_ack_backlog: u32,        // Offset 604
+    pub sk_drops: i32,              // Offset 136
 }
 
 #[map(name = "net_metrics")]

--- a/core/src/components/metrics_tracer/src/main.rs
+++ b/core/src/components/metrics_tracer/src/main.rs
@@ -3,20 +3,17 @@
 #![allow(warnings)]
 
 mod bindings;
+mod data_structures;
 
 use crate::bindings::net_device;
 use aya_ebpf::EbpfContext;
 use aya_ebpf::helpers::{bpf_probe_read_kernel, bpf_probe_read_kernel_str_bytes};
 use aya_ebpf::macros::{kprobe, map};
-use aya_ebpf::maps::PerfEventArray;
+use aya_ebpf::maps::{HashMap, PerfEventArray};
 use aya_ebpf::programs::ProbeContext;
-
-struct NetworkMetrics {
-    src_addr: [u32; 8],
-}
-
-#[map(name = "net_metrics")]
-pub static NET_METRICS: PerfEventArray<NetworkMetrics> = PerfEventArray::new(0);
+use aya_ebpf::helpers::bpf_get_current_pid_tgid;
+use crate::data_structures::NetworkMetrics;
+use crate::data_structures::NET_METRICS;
 
 #[kprobe]
 fn metrics_tracer(ctx: ProbeContext) -> u32 {
@@ -27,45 +24,36 @@ fn metrics_tracer(ctx: ProbeContext) -> u32 {
 }
 
 fn try_metrics_tracer(ctx: ProbeContext) -> Result<u32, i64> {
-    let net_device_pointer: *const net_device = ctx.arg(0).ok_or(1i64)?;
+    let sk_pointer = ctx.arg::<*const u8>(0).ok_or(1i64)?;
 
-    if net_device_pointer.is_null() {
+    if sk_pointer.is_null() {
         return Err(1);
     }
 
-    //let sk_pacing_status_offset = 428;
-    //let sk_pacing_status_pointer =
-    //  unsafe { (sk_pacing_status_offset as *const u8).add(sk_pacing_status_offset) };
+    let sk_err_offset = 284;
+    let sk_err_soft_offset = 600;
+    let sk_backlog_len_offset = 196;
+    let sk_wmem_queued_offset = 376;
+    let sk_rcvbuf_offset = 244;
+    let sk_ack_backlog_offset = 604;
+    let sk_drops_offset = 136;
 
-    //let sk_pacing_status = unsafe {
-    //match bpf_probe_read_kernel(sk_pacing_status_pointer) {
-    //Ok(value) => value,
-    //Err(ret) => {
-    //      return Err(ret);
-    //    }
-    //  }
-    //};
-
-    let dev_addr_offset = 1080;
-
-    let dev_addr_pointer = unsafe { (net_device_pointer as *const u8).add(dev_addr_offset) };
-
-    let mut dev_addr_buf = [0u32; 8];
-
-    let dev_addr_ptr_array = dev_addr_pointer as *const [u32; 8];
-    let dev_addr_array = unsafe {
-        match bpf_probe_read_kernel(dev_addr_ptr_array) {
-            Ok(arr) => arr,
-            Err(ret) => {
-                return Err(ret);
-            }
-        }
-    };
-
-    dev_addr_buf.copy_from_slice(&dev_addr_array);
+    let sk_err = unsafe { bpf_probe_read_kernel::<i32>(sk_pointer.add(sk_err_offset) as *const i32).map_err(|_| 1)? };
+    let sk_err_soft = unsafe { bpf_probe_read_kernel::<i32>(sk_pointer.add(sk_err_soft_offset) as *const i32).map_err(|_| 1)? };
+    let sk_backlog_len = unsafe { bpf_probe_read_kernel::<i32>(sk_pointer.add(sk_backlog_len_offset) as *const i32).map_err(|_| 1)? };
+    let sk_wmem_queued = unsafe { bpf_probe_read_kernel::<i32>(sk_pointer.add(sk_wmem_queued_offset) as *const i32).map_err(|_| 1)? };
+    let sk_rcvbuf = unsafe { bpf_probe_read_kernel::<i32>(sk_pointer.add(sk_rcvbuf_offset) as *const i32).map_err(|_| 1)? };
+    let sk_ack_backlog = unsafe { bpf_probe_read_kernel::<u32>(sk_pointer.add(sk_ack_backlog_offset) as *const u32).map_err(|_| 1)? };
+    let sk_drops = unsafe { bpf_probe_read_kernel::<i32>(sk_pointer.add(sk_drops_offset) as *const i32).map_err(|_| 1)? };
 
     let net_metrics = NetworkMetrics {
-        src_addr: dev_addr_buf,
+        sk_err,
+        sk_err_soft,
+        sk_backlog_len,
+        sk_wmem_queued,
+        sk_rcvbuf,
+        sk_ack_backlog,
+        sk_drops,
     };
 
     unsafe {
@@ -75,6 +63,10 @@ fn try_metrics_tracer(ctx: ProbeContext) -> Result<u32, i64> {
     Ok(0)
 }
 
+// Monitor on tcp_sendmsg, tcp_v4_connect
+
+
+// panic handler
 #[panic_handler]
 fn panic(_info: &core::panic::PanicInfo) -> ! {
     loop {}

--- a/core/src/components/metrics_tracer/src/main.rs
+++ b/core/src/components/metrics_tracer/src/main.rs
@@ -33,16 +33,16 @@ fn try_metrics_tracer(ctx: ProbeContext) -> Result<u32, i64> {
     let sk_err_offset = 284;
     let sk_err_soft_offset = 600;
     let sk_backlog_len_offset = 196;
-    let sk_wmem_queued_offset = 376;
-    let sk_rcvbuf_offset = 244;
+    let sk_write_memory_queued_offset = 376;
+    let sk_receive_buffer_size_offset = 244;
     let sk_ack_backlog_offset = 604;
     let sk_drops_offset = 136;
 
     let sk_err = unsafe { bpf_probe_read_kernel::<i32>(sk_pointer.add(sk_err_offset) as *const i32).map_err(|_| 1)? };
     let sk_err_soft = unsafe { bpf_probe_read_kernel::<i32>(sk_pointer.add(sk_err_soft_offset) as *const i32).map_err(|_| 1)? };
     let sk_backlog_len = unsafe { bpf_probe_read_kernel::<i32>(sk_pointer.add(sk_backlog_len_offset) as *const i32).map_err(|_| 1)? };
-    let sk_wmem_queued = unsafe { bpf_probe_read_kernel::<i32>(sk_pointer.add(sk_wmem_queued_offset) as *const i32).map_err(|_| 1)? };
-    let sk_rcvbuf = unsafe { bpf_probe_read_kernel::<i32>(sk_pointer.add(sk_rcvbuf_offset) as *const i32).map_err(|_| 1)? };
+    let sk_write_memory_queued = unsafe { bpf_probe_read_kernel::<i32>(sk_pointer.add(sk_wmem_queued_offset) as *const i32).map_err(|_| 1)? };
+    let sk_receive_buffer_size = unsafe { bpf_probe_read_kernel::<i32>(sk_pointer.add(sk_rcvbuf_offset) as *const i32).map_err(|_| 1)? };
     let sk_ack_backlog = unsafe { bpf_probe_read_kernel::<u32>(sk_pointer.add(sk_ack_backlog_offset) as *const u32).map_err(|_| 1)? };
     let sk_drops = unsafe { bpf_probe_read_kernel::<i32>(sk_pointer.add(sk_drops_offset) as *const i32).map_err(|_| 1)? };
 
@@ -50,8 +50,8 @@ fn try_metrics_tracer(ctx: ProbeContext) -> Result<u32, i64> {
         sk_err,
         sk_err_soft,
         sk_backlog_len,
-        sk_wmem_queued,
-        sk_rcvbuf,
+        sk_write_memory_queued,
+        sk_receive_buffer_size,
         sk_ack_backlog,
         sk_drops,
     };

--- a/core/src/components/metrics_tracer/src/mod.rs
+++ b/core/src/components/metrics_tracer/src/mod.rs
@@ -1,1 +1,2 @@
 mod bindings;
+mod data_structures;

--- a/core/src/testing/chaos-mess.yaml
+++ b/core/src/testing/chaos-mess.yaml
@@ -1,0 +1,18 @@
+kind: NetworkChaos
+apiVersion: chaos-mesh.org/v1alpha1
+metadata:
+  namespace: cortexflow
+  name: test
+spec:
+  selector:
+    namespaces:
+      - cortexflow
+    labelSelectors:
+      app: cortexflow-metrics
+  mode: all
+  action: loss
+  duration: 60s
+  loss:
+    loss: '20'
+    correlation: '0'
+  direction: to

--- a/core/src/testing/metrics.yaml
+++ b/core/src/testing/metrics.yaml
@@ -19,7 +19,7 @@ spec:
       hostNetwork: true
       containers:
         - name: metrics
-          image: metrics:0.0.1
+          image: lorenzotettamanti/cortexflow-metrics:latest
           command: ["/bin/bash", "-c"]
           args:
             - |

--- a/core/src/testing/metrics.yaml
+++ b/core/src/testing/metrics.yaml
@@ -19,7 +19,7 @@ spec:
       hostNetwork: true
       containers:
         - name: metrics
-          image: lorenzotettamanti/cortexflow-metrics:latest
+          image: metrics:0.0.1
           command: ["/bin/bash", "-c"]
           args:
             - |


### PR DESCRIPTION
Here is the working screenshot

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/bab1ad71-da80-4123-9850-56a275f28a1b" />


metrics considered are along side total drops

| Field            | Offset | Meaning                                                                 |
|------------------|--------|-------------------------------------------------------------------------|
| `sk_err`         | 284    | Last socket error, e.g. `ECONNRESET`, may include some data loss        |
| `sk_err_soft`    | 600    | Temporary errors (e.g., buffer full), cleared more frequently           |
| `sk_backlog.len` | 196    | Number of packets waiting in backlog (not loss, but congestion insight) |
| `sk_wmem_queued` | 376    | Amount of data queued for write (can indicate TX congestion)            |
| `sk_rcvbuf`      | 244    | Receive buffer size (for context when evaluating `sk_drops`)            |
| `sk_ack_backlog` | 604    | Current backlog queue length for connections (useful in TCP)            |
