### PR TITLE
[CortexFlow#140]: only print 0 events via info macro

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,7 +23,7 @@ tonic = "0.14.1"
 tonic-reflection = "0.14.1"
 prost-types = "0.14.1"
 prost = "0.14.1"
-cortexflow_agent_api = "0.1.1-beta.1"
+cortexflow_agent_api = "0.1.1-beta.2"
 
 [[bin]]
 name = "cfcli"

--- a/core/api/Cargo.toml
+++ b/core/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cortexflow_agent_api"
-version = "0.1.1-beta.1"
+version = "0.1.1-beta.2"
 edition = "2021"
 description = "CortexFlow agent API"
 authors = ["Lorenzo Tettamanti", "Pranav Verma", "Lorenzo Bradanini","Siddharth Sutar","Andrea Bozzo"]

--- a/core/api/src/api.rs
+++ b/core/api/src/api.rs
@@ -181,13 +181,6 @@ impl Default for AgentApi {
                                 }
                             } else if events.read == 0 {
                                 info!("[Agent/API] 0 Events found");
-                                let mut evt = Vec::new();
-                                evt.push(ConnectionEvent {
-                                    event_id: "0".to_string(),
-                                    src_ip_port: "0:0".to_string(),
-                                    dst_ip_port: "0:0".to_string(),
-                                });
-                                let _ = tx.send(Ok(evt)).await;
                             }
                         }
                         Err(e) => {


### PR DESCRIPTION
Zero events are no longer sent to buffers

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/3a3ccb5b-561a-4cbc-b2ad-58a911f35406" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/50a046bb-1d96-4569-bfb1-d75a95a8c303" />


@LorenzoTettamanti please check