### PR TITLE
Fixed container.name null bug when using Docker. Updated metadata enrichment for k8s environments. Added service cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,4 @@ CLAUDE.md
 bindings.rs
 site/
 *.jsonc
+*.txt

--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,4 @@ CLAUDE.md
 
 bindings.rs
 site/
+*.jsonc

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -458,7 +458,7 @@ dependencies = [
  "aya-log",
  "bytemuck",
  "bytes",
- "cortexbrain-common 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cortexbrain-common 0.1.2",
  "libc",
  "nix",
  "opentelemetry",

--- a/core/api/Dockerfile
+++ b/core/api/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN cargo install --locked bindgen-cli
-RUN cargo install --locked bpf-linker
+RUN cargo install --locked bpf-linker@0.10.4
 RUN rustup toolchain install nightly --component rust-src
 
 WORKDIR /usr/src/app

--- a/core/common/Cargo.toml
+++ b/core/common/Cargo.toml
@@ -24,7 +24,7 @@ opentelemetry-otlp = { version = "0.32.0", features = ["logs", "grpc-tonic"] }
 bytemuck = "1.25.0"
 bytes = "1.11.0"
 bytemuck_derive = "1.10.2"
-tokio = "1.49.0"
+tokio = {version="1.49.0",features=["sync"]}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/core/common/src/buffer_type.rs
+++ b/core/common/src/buffer_type.rs
@@ -110,6 +110,7 @@ pub struct PacketLossMetrics {
     pub sk_receive_buffer_size: i32, // Offset 244
     pub sk_ack_backlog: u32,         // Offset 604
     pub sk_drops: i32,               // Offset 136
+    pub cgroup_id: u64,
 }
 #[cfg(feature = "monitoring-structs")]
 unsafe impl aya::Pod for PacketLossMetrics {}
@@ -129,6 +130,7 @@ pub struct TimeStampMetrics {
     pub daddr_v4: u32,
     pub saddr_v6: [u32; 4],
     pub daddr_v6: [u32; 4],
+    pub cgroup_id: u64,
 }
 #[cfg(feature = "monitoring-structs")]
 unsafe impl aya::Pod for TimeStampMetrics {}
@@ -151,6 +153,7 @@ pub struct MemAlloc {
     pub length: u64,
     pub addr: u64,
     pub command: [u8; TASK_COMM_LEN],
+    pub cgroup_id: u64,
 }
 #[cfg(feature = "monitoring-structs")]
 unsafe impl aya::Pod for MemAlloc {}
@@ -162,6 +165,7 @@ pub struct SchedStatWait {
     pub tgid: u32,
     pub delay: u64,
     pub command: [u8; TASK_COMM_LEN],
+    pub cgroup_id: u64,
 }
 #[cfg(feature = "monitoring-structs")]
 unsafe impl aya::Pod for SchedStatWait {}
@@ -173,6 +177,7 @@ pub struct SchedStatRuntime {
     pub tgid: u32,
     pub runtime: u64,
     pub command: [u8; TASK_COMM_LEN],
+    pub cgroup_id: u64,
 }
 #[cfg(feature = "monitoring-structs")]
 unsafe impl aya::Pod for SchedStatRuntime {}
@@ -197,6 +202,7 @@ pub struct SslEvent {
     pub direction: u8,  // 0 = read, 1 = write
     pub size: i32,      // return value (bytes transferred or <0 on error)
     pub requested: i32, // num argument passed to SSL_read/SSL_write
+    pub cgroup_id: u64,
 }
 unsafe impl aya::Pod for SslEvent {}
 

--- a/core/common/src/consumer.rs
+++ b/core/common/src/consumer.rs
@@ -22,9 +22,12 @@ use crate::buffer_type::{PacketLog, TcpPacketRegistry, VethLog};
 use crate::metadata::Metadata;
 #[cfg(feature = "monitoring-structs")]
 use crate::otel_metrics::Metrics;
+use crate::service_cache::ServiceCache;
 use bytes::BytesMut;
 #[cfg(feature = "monitoring-structs")]
 use std::sync::Arc;
+#[cfg(feature = "buffer-reader")]
+use tokio::sync::RwLock;
 use tracing::{error, info, warn};
 
 /// Discriminator for perf-buffer event types consumed by the collector.
@@ -271,6 +274,7 @@ impl Consumer {
         offset: i32,
         exporter: &str,
         metrics: Arc<Metrics>,
+        cache: Arc<RwLock<ServiceCache>>,
     ) {
         for i in offset..tot_events {
             let vec_bytes = &buffers[i as usize];
@@ -293,9 +297,12 @@ impl Consumer {
 
                 match exporter {
                     "otlp" => {
-                        let mut metadata =
-                            Metadata::from_ebpf(Some(packet_loss.tgid), &packet_loss.comm);
-                        metadata.enrich();
+                        let mut metadata = Metadata::from_ebpf(
+                            Some(packet_loss.tgid),
+                            Some(packet_loss.cgroup_id),
+                            &packet_loss.comm,
+                        );
+                        metadata.enrich(&cache).await;
                         metrics.record_packet_loss_metrics(&packet_loss, &metadata);
                     }
                     _ => continue,
@@ -313,7 +320,8 @@ impl Consumer {
                 let sk_receive_buffer_size = packet_loss.sk_receive_buffer_size;
 
                 info!(
-                    "tgid: {}, comm: {}, ts_us: {}, sk_drops: {}, sk_err: {}, sk_err_soft: {}, sk_backlog_len: {}, sk_write_memory_queued: {}, sk_ack_backlog: {}, sk_receive_buffer_size: {}",
+                    "tgid: {}, comm: {}, ts_us: {}, sk_drops: {}, sk_err: {}, sk_err_soft: {}, sk_backlog_len: {}, 
+                    sk_write_memory_queued: {}, sk_ack_backlog: {}, sk_receive_buffer_size: {}",
                     tgid,
                     comm,
                     ts_us,
@@ -323,7 +331,7 @@ impl Consumer {
                     sk_backlog_len,
                     sk_write_memory_queued,
                     sk_ack_backlog,
-                    sk_receive_buffer_size
+                    sk_receive_buffer_size,
                 );
             }
         }
@@ -339,6 +347,7 @@ impl Consumer {
         offset: i32,
         exporter: &str,
         metrics: Arc<Metrics>,
+        cache: Arc<RwLock<ServiceCache>>,
     ) {
         for i in offset..tot_events {
             let vec_bytes = &buffers[i as usize];
@@ -363,9 +372,10 @@ impl Consumer {
                     "otlp" => {
                         let mut metadata = Metadata::from_ebpf(
                             Some(time_stamp_event.tgid),
+                            Some(time_stamp_event.cgroup_id),
                             &time_stamp_event.comm,
                         );
-                        metadata.enrich();
+                        metadata.enrich(&cache).await;
                         metrics.record_timestamp_metrics(&time_stamp_event, &metadata);
                     }
                     _ => continue,
@@ -394,6 +404,7 @@ impl Consumer {
         offset: i32,
         exporter: &str,
         metrics: Arc<Metrics>,
+        cache: Arc<RwLock<ServiceCache>>,
     ) {
         for i in offset..tot_events {
             let vec_bytes = &buffers[i as usize];
@@ -418,9 +429,10 @@ impl Consumer {
                     "otlp" => {
                         let mut metadata = Metadata::from_ebpf(
                             Some(cpu_freq_metrics.pid),
+                            None,
                             &cpu_freq_metrics.command,
                         );
-                        metadata.enrich();
+                        metadata.enrich(&cache).await;
                         metrics.record_cpu_bytes_alloc(&cpu_freq_metrics, &metadata);
                     }
                     _ => continue,
@@ -445,6 +457,7 @@ impl Consumer {
         offset: i32,
         exporter: &str,
         metrics: Arc<Metrics>,
+        cache: Arc<RwLock<ServiceCache>>,
     ) {
         for i in offset..tot_events {
             let vec_bytes = &buffers[i as usize];
@@ -467,9 +480,12 @@ impl Consumer {
 
                 match exporter {
                     "otlp" => {
-                        let mut metadata =
-                            Metadata::from_ebpf(Some(mem_alloc.tgid), &mem_alloc.command);
-                        metadata.enrich();
+                        let mut metadata = Metadata::from_ebpf(
+                            Some(mem_alloc.tgid),
+                            Some(mem_alloc.cgroup_id),
+                            &mem_alloc.command,
+                        );
+                        metadata.enrich(&cache).await;
                         metrics.record_enter_mem_alloc(&mem_alloc, &metadata);
                     }
                     _ => continue,
@@ -496,6 +512,7 @@ impl Consumer {
         offset: i32,
         exporter: &str,
         metrics: Arc<Metrics>,
+        cache: Arc<RwLock<ServiceCache>>,
     ) {
         for i in offset..tot_events {
             let vec_bytes = &buffers[i as usize];
@@ -520,9 +537,10 @@ impl Consumer {
                     "otlp" => {
                         let mut metadata = Metadata::from_ebpf(
                             Some(sched_stat_wait.tgid),
+                            Some(sched_stat_wait.cgroup_id),
                             &sched_stat_wait.command,
                         );
-                        metadata.enrich();
+                        metadata.enrich(&cache).await;
                         metrics.record_sched_stat_wait(&sched_stat_wait, &metadata);
                     }
                     _ => continue,
@@ -548,6 +566,7 @@ impl Consumer {
         offset: i32,
         exporter: &str,
         metrics: Arc<Metrics>,
+        cache: Arc<RwLock<ServiceCache>>,
     ) {
         for i in offset..tot_events {
             let vec_bytes = &buffers[i as usize];
@@ -572,9 +591,10 @@ impl Consumer {
                     "otlp" => {
                         let mut metadata = Metadata::from_ebpf(
                             Some(sched_stat_runtime.tgid),
+                            Some(sched_stat_runtime.cgroup_id),
                             &sched_stat_runtime.command,
                         );
-                        metadata.enrich();
+                        metadata.enrich(&cache).await;
                         metrics.record_sched_stat_runtime(&sched_stat_runtime, &metadata);
                     }
                     _ => continue,
@@ -600,6 +620,7 @@ impl Consumer {
         offset: i32,
         exporter: &str,
         metrics: Arc<Metrics>,
+        cache: Arc<RwLock<ServiceCache>>,
     ) {
         for i in offset..tot_events {
             let vec_bytes = &buffers[i as usize];
@@ -622,7 +643,7 @@ impl Consumer {
 
                 match exporter {
                     "otlp" => {
-                        let metadata = Metadata::from_ebpf(None, &[]);
+                        let metadata = Metadata::from_ebpf(None, None, &[]);
                         metrics.record_cpu_idle(&cpu_idle, &metadata);
                     }
                     _ => continue,
@@ -645,6 +666,7 @@ impl Consumer {
         offset: i32,
         exporter: &str,
         metrics: Arc<Metrics>,
+        cache: Arc<RwLock<ServiceCache>>,
     ) {
         for i in offset..tot_events {
             use crate::buffer_type::SslEvent;
@@ -673,8 +695,12 @@ impl Consumer {
                     // 0 = read // 1= write
                     0 => match exporter {
                         "otlp" => {
-                            let mut metadata = Metadata::from_ebpf(None, &[]);
-                            metadata.enrich();
+                            let mut metadata = Metadata::from_ebpf(
+                                Some(ssl_event.tgid),
+                                Some(ssl_event.cgroup_id),
+                                &ssl_event.comm,
+                            );
+                            metadata.enrich(&cache).await;
                             metrics.record_ssl_read_bytes(&ssl_event, &metadata);
                             let tgid = ssl_event.tgid;
                             let command = String::from_utf8_lossy(&ssl_event.comm);
@@ -690,8 +716,12 @@ impl Consumer {
                     },
                     1 => match exporter {
                         "otlp" => {
-                            let mut metadata = Metadata::from_ebpf(None, &[]);
-                            metadata.enrich();
+                            let mut metadata = Metadata::from_ebpf(
+                                Some(ssl_event.tgid),
+                                Some(ssl_event.cgroup_id),
+                                &ssl_event.comm,
+                            );
+                            metadata.enrich(&cache).await;
                             metrics.record_ssl_write_bytes(&ssl_event, &metadata);
                             let tgid = ssl_event.tgid;
                             let command = String::from_utf8_lossy(&ssl_event.comm);
@@ -729,6 +759,7 @@ pub async fn read_perf_buffer<T: std::borrow::BorrowMut<aya::maps::MapData>>(
     mut buffers: Vec<bytes::BytesMut>,
     consumer: Consumer,
     #[cfg(feature = "monitoring-structs")] metrics: Option<Arc<Metrics>>,
+    cache: Option<Arc<RwLock<ServiceCache>>>,
 ) {
     loop {
         for buf in array_buffers.iter_mut() {
@@ -767,6 +798,7 @@ pub async fn read_perf_buffer<T: std::borrow::BorrowMut<aya::maps::MapData>>(
                                     metrics
                                         .clone()
                                         .expect("Metrics required for PacketLossMetrics"),
+                                    cache.clone().expect("cache required for PacketLossMetrics"),
                                 )
                                 .await
                             }
@@ -780,6 +812,7 @@ pub async fn read_perf_buffer<T: std::borrow::BorrowMut<aya::maps::MapData>>(
                                     metrics
                                         .clone()
                                         .expect("Metric required for TimeStampMetrics"),
+                                    cache.clone().expect("cache required for PacketLossMetrics"),
                                 )
                                 .await
                             }
@@ -791,6 +824,7 @@ pub async fn read_perf_buffer<T: std::borrow::BorrowMut<aya::maps::MapData>>(
                                     offset,
                                     "otlp",
                                     metrics.clone().expect("Metric required for CpuFrequency"),
+                                    cache.clone().expect("cache required for PacketLossMetrics"),
                                 )
                                 .await
                             }
@@ -802,6 +836,7 @@ pub async fn read_perf_buffer<T: std::borrow::BorrowMut<aya::maps::MapData>>(
                                     offset,
                                     "otlp",
                                     metrics.clone().expect("Metric required for MemAlloc"),
+                                    cache.clone().expect("cache required for PacketLossMetrics"),
                                 )
                                 .await
                             }
@@ -813,6 +848,7 @@ pub async fn read_perf_buffer<T: std::borrow::BorrowMut<aya::maps::MapData>>(
                                     offset,
                                     "otlp",
                                     metrics.clone().expect("Metric required for SchedStatWait"),
+                                    cache.clone().expect("cache required for PacketLossMetrics"),
                                 )
                                 .await
                             }
@@ -826,6 +862,7 @@ pub async fn read_perf_buffer<T: std::borrow::BorrowMut<aya::maps::MapData>>(
                                     metrics
                                         .clone()
                                         .expect("Metric required for SchedStatRuntime"),
+                                    cache.clone().expect("cache required for PacketLossMetrics"),
                                 )
                                 .await
                             }
@@ -837,6 +874,7 @@ pub async fn read_perf_buffer<T: std::borrow::BorrowMut<aya::maps::MapData>>(
                                     offset,
                                     "otlp",
                                     metrics.clone().expect("Metric required for CpuIdle"),
+                                    cache.clone().expect("cache required for PacketLossMetrics"),
                                 )
                                 .await
                             }
@@ -848,6 +886,7 @@ pub async fn read_perf_buffer<T: std::borrow::BorrowMut<aya::maps::MapData>>(
                                     offset,
                                     "otlp",
                                     metrics.clone().expect("Metric required for SslEvents"),
+                                    cache.clone().expect("cache required for PacketLossMetrics"),
                                 )
                                 .await
                             }

--- a/core/common/src/consumer.rs
+++ b/core/common/src/consumer.rs
@@ -898,6 +898,6 @@ pub async fn read_perf_buffer<T: std::borrow::BorrowMut<aya::maps::MapData>>(
                 }
             }
         }
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(5000)).await;
     }
 }

--- a/core/common/src/consumer.rs
+++ b/core/common/src/consumer.rs
@@ -24,7 +24,7 @@ use crate::metadata::Metadata;
 use crate::otel_metrics::Metrics;
 use crate::service_cache::ServiceCache;
 use bytes::BytesMut;
-#[cfg(feature = "monitoring-structs")]
+#[cfg(feature = "buffer-reader")]
 use std::sync::Arc;
 #[cfg(feature = "buffer-reader")]
 use tokio::sync::RwLock;

--- a/core/common/src/lib.rs
+++ b/core/common/src/lib.rs
@@ -19,3 +19,4 @@ pub mod metadata;
 pub mod consumer;
 #[cfg(feature = "experimental")]
 pub mod service_discovery;
+pub mod service_cache;

--- a/core/common/src/logger.rs
+++ b/core/common/src/logger.rs
@@ -49,6 +49,7 @@ const OTEL_EXPORTER_OTLP_ENDPOINT: &str = "OTEL_EXPORTER_OTLP_ENDPOINT";
 const OTEL_EXPORTER_OTLP_PROTOCOL: &str = "OTEL_EXPORTER_OTLP_PROTOCOL";
 const DEFAULT_OTLP_GRPC_ENDPOINT: &str = "http://localhost:4317";
 const DEFAULT_OTLP_HTTP_ENDPOINT: &str = "http://localhost:4318";
+const CF_DEBUG_LEVEL: &str = "CF_DEBUG_LEVEL";
 
 fn resolved_otlp_endpoint() -> String {
     if let Ok(endpoint) = std::env::var(OTEL_EXPORTER_OTLP_ENDPOINT)
@@ -115,7 +116,8 @@ pub fn otlp_logger_init(service_name: String) -> SdkLoggerProvider {
     let otel_layer = OpenTelemetryTracingBridge::new(&provider);
 
     // init fmt filter and layer
-    let fmt_filter = EnvFilter::new("info").add_directive("opentelemetry=debug".parse().unwrap());
+    let fmt_filter = EnvFilter::new(std::env::var(CF_DEBUG_LEVEL).unwrap_or("debug".to_string()))
+        .add_directive("opentelemetry=debug".parse().unwrap());
     let fmt_layer = tracing_subscriber::fmt::layer()
         .with_thread_names(true)
         .with_line_number(false)

--- a/core/common/src/metadata.rs
+++ b/core/common/src/metadata.rs
@@ -1,11 +1,14 @@
-use std::collections::HashMap;
-use std::fs;
 use anyhow::Error;
-use k8s_openapi::api::core::v1::Pod;
-use kube::api::ObjectList;
-use kube::{Api, Client};
-use tracing::debug;
+use std::fs;
+use std::os::unix::fs::MetadataExt;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tracing::{debug, info};
 
+use crate::service_cache::ServiceCache;
+
+// TODO: add containerd tracing and mutual exclusion for docker environments
 
 /// Detected container runtime.
 #[derive(Debug, Clone, PartialEq)]
@@ -16,27 +19,28 @@ pub enum ContainerRuntime {
 }
 
 /// Process / container metadata enriched by service discovery.
-///
 /// Built from raw eBPF data and enriched with a cgroup -> Docker -> K8s lookup.
 #[derive(Debug, Clone)]
 pub struct Metadata {
     pub tgid: Option<u32>,
+    pub cgroup_id: Option<u64>,
     pub command: String,
     pub runtime: ContainerRuntime,
     pub container_name: Option<String>,
     pub container_id: Option<String>,
     pub pod_name: Option<String>,
-    pub namespace: Option<String>,
+    pub namespace: Option<String>, // TODO: implement this one
 }
 
 impl Metadata {
     /// Build base metadata from eBPF data.
-    pub fn from_ebpf(tgid: Option<u32>, command: &[u8]) -> Self {
+    pub fn from_ebpf(tgid: Option<u32>, cgroup_id: Option<u64>, command: &[u8]) -> Self {
         let command = String::from_utf8_lossy(command)
             .trim_end_matches('\0')
             .to_string();
         Self {
             tgid,
+            cgroup_id,
             command,
             runtime: ContainerRuntime::Unknown,
             container_name: None,
@@ -46,15 +50,69 @@ impl Metadata {
         }
     }
 
-    /// Lookup rules: first Docker (filesystem), then Kubernetes (API).
+    /// Lookup rules: prefer cgroup_id (v2), fall back to /proc/<tgid>/cgroup (v1).
     ///
-    /// 1. Reads `/proc/<tgid>/cgroup`.
-    /// 2. Extracts the container ID from the cgroup path.
-    /// 3. Tries to resolve the container name from `/var/lib/docker/containers/<id>/config.v2.json`.
-    /// 4. If Docker is not found, attempts K8s lookup.
-    pub fn enrich(&mut self) {
-        self.try_resolve_docker();
-        self.try_resolve_k8s();
+    /// 1. If cgroup_id is set and non-zero, resolve it via /sys/fs/cgroup (cgroup v2).
+    /// 2. Otherwise (cgroup v1, or eBPF didn't provide cgroup_id), fall back to reading
+    ///    /host/proc/<tgid>/cgroup.
+    pub async fn enrich(&mut self, cache: &Arc<RwLock<ServiceCache>>) {
+        if let Some(cgid) = self.cgroup_id
+            && cgid != 0
+            && detect_cgroup_v2()
+            && self.try_resolve_from_cgroup_id(cgid, cache).await
+        {
+            return;
+        } else {
+            debug!("cgroup_v2 not detected. Using cgroup v1");
+            self.try_resolve_docker();
+        }
+        self.try_resolve_k8s(cache).await;
+    }
+
+    /// Resolve pod/container from a kernel cgroup_id by walking /sys/fs/cgroup (v2).
+    /// Returns true if resolution succeeded (pod_uid extracted), false to allow caller fallback.
+    async fn try_resolve_from_cgroup_id(
+        &mut self,
+        cgroup_id: u64,
+        cache: &Arc<RwLock<ServiceCache>>,
+    ) -> bool {
+        let Some(cgroup_path) = find_cgroup_path_by_id(cgroup_id) else {
+            debug!(
+                "cgroup_id {} not found under {}",
+                cgroup_id, "/host/sys/fs/cgroup"
+            );
+            return false;
+        };
+
+        if let Some(id) = extract_pod_uid(cgroup_path.to_string_lossy().to_string()) {
+            self.container_id = Some(id.clone());
+            self.runtime = ContainerRuntime::Kubernetes;
+
+            // get pod from cache
+            // acquire cache lock
+            let cache_lock = cache.read().await;
+            match cache_lock.get_from_cache(&id).await {
+                Some(name) => self.pod_name = Some(name),
+                None => {
+                    // fallback to the container_id if the k8s API cannot resolve the name
+                    self.pod_name = Some(id.clone());
+                }
+            }
+            return true;
+        }
+
+        // not a k8s pod cgroup — try docker/containerd/crio container id
+        if let Some(id) = extract_container_id_from_path(&cgroup_path.to_string_lossy()) {
+            self.container_id = Some(id.clone());
+            self.runtime = ContainerRuntime::Docker;
+            match resolve_docker_name(&id) {
+                Some(name) => self.container_name = Some(name),
+                None => self.container_name = self.container_id.clone(),
+            }
+            return true;
+        }
+
+        false
     }
 
     /// Docker resolution via local filesystem.
@@ -64,92 +122,79 @@ impl Metadata {
         let Some(tgid) = self.tgid else { return };
 
         // Step 1: read the cgroup path from procfs
-        let cgroup_info = match fs::read_to_string(format!("/proc/{}/cgroup", tgid)) {
-            Ok(s) => s,
-            Err(e) => {
-                tracing::debug!("Cannot read /proc/{}/cgroup: {}", tgid, e);
+        if let Some(cgroup_info) = get_cgroup_info(tgid) {
+            // Extract the actual path from the cgroup file (format: hierarchy:id:path)
+            let cgroup_path = cgroup_info
+                .lines()
+                .filter_map(|line| line.split(':').nth(2))
+                .next()
+                .unwrap_or("");
+
+            if cgroup_path.is_empty() {
+                info!("cgroup_path is empty");
                 return;
             }
-        };
 
-        // Extract the actual path from the cgroup file (format: hierarchy:id:path)
-        let cgroup_path = cgroup_info
-            .lines()
-            .filter_map(|line| line.split(':').nth(2))
-            .next()
-            .unwrap_or("");
+            // Step 2: extract container ID from the path
+            if let Some(id) = extract_container_id_from_path(cgroup_path) {
+                self.container_id = Some(id.clone());
+                self.runtime = ContainerRuntime::Docker;
 
-        if cgroup_path.is_empty() {
-            return;
-        }
-
-        // Step 2: extract container ID from the path
-        if let Some(id) = extract_container_id_from_path(cgroup_path) {
-            self.container_id = Some(id.clone());
-            self.runtime = ContainerRuntime::Docker;
-
-            // Step 3: resolve container name from Docker metadata JSON
-            match resolve_docker_name(&id) {
-                Some(name) => self.container_name = Some(name),
-                None => {
-                    self.container_name =
-                        Some(self.container_id.clone()).expect("Cannot resolve container name")
-                } // fallback to the container_id if the system cannot resolve the name after the 2 steps
+                // Step 3: resolve container name from Docker metadata JSON
+                match resolve_docker_name(&id) {
+                    Some(name) => self.container_name = Some(name),
+                    None => {
+                        self.container_name = self.container_id.clone(); // fallback to the container_id if the system cannot resolve the name after the 2 steps
+                    }
+                }
             }
-        }
+        };
     }
 
-    fn try_resolve_k8s(&mut self){
+    async fn try_resolve_k8s(&mut self, cache: &Arc<RwLock<ServiceCache>>) {
         let Some(tgid) = self.tgid else { return };
 
         // Step 1: read the cgroup path from procfs
-        let cgroup_info = match fs::read_to_string(format!("/proc/{}/cgroup", tgid)) {
-            Ok(s) => s,
-            Err(e) => {
-                tracing::debug!("Cannot read /proc/{}/cgroup: {}", tgid, e);
+        if let Some(cgroup_info) = get_cgroup_info(tgid) {
+            // Extract the actual path from the cgroup file (format: hierarchy:id:path)
+            let cgroup_path = cgroup_info
+                .lines()
+                .filter_map(|line| line.split(':').nth(2))
+                .next()
+                .unwrap_or("");
+
+            if cgroup_path.is_empty() {
+                info!("cgroup_path is empty");
                 return;
             }
-        };
 
-        // Extract the actual path from the cgroup file (format: hierarchy:id:path)
-        let cgroup_path = cgroup_info
-            .lines()
-            .filter_map(|line| line.split(':').nth(2))
-            .next()
-            .unwrap_or("");
+            // Step 2: extract container ID from the path
+            if let Some(id) = extract_pod_uid(cgroup_path.to_string()) {
+                self.container_id = Some(id.clone());
+                self.runtime = ContainerRuntime::Kubernetes;
 
-        if cgroup_path.is_empty() {
-            return;
-        }
+                // Step 3: resolve container name from the k8s API
 
-        // Step 2: extract container ID from the path
-        if let Some(id) = extract_container_id_from_path(cgroup_path) {
-            self.container_id = Some(id.clone());
-            self.runtime = ContainerRuntime::Kubernetes;
+                //acquire cache lock
+                let cache_lock = cache.read().await;
 
-            // Step 3: resolve container name from Docker metadata JSON
-            match resolve_k8s_name(&id) {
-                Some(name) => self.container_name = Some(name),
-                None => {
-                    self.container_name =
-                        Some(self.container_id.clone()).expect("Cannot resolve container name from k8s api ")
-                } // fallback to the container_id if the system cannot resolve the name after the 2 steps
+                match cache_lock.get_from_cache(&id).await {
+                    Some(name) => self.pod_name = Some(name),
+                    None => {
+                        // fallback to the container_id if the k8s API cannot resolve the name
+                        self.pod_name = Some(id.clone());
+                    }
+                }
             }
         }
-
-        //Step 3: call the k8s API to solve the container nam e
     }
-
-    // TODO: dead code 
-    // Enrichment from Kubernetes (for external use, e.g. identity service).
-    //pub fn enrich_from_k8s(&mut self, pod_name: impl Into<String>, namespace: impl Into<String>) {
-    //    self.runtime = ContainerRuntime::Kubernetes;
-    //    self.pod_name = Some(pod_name.into());
-    //    self.namespace = Some(namespace.into());
-    //}
 }
 
-/// Extract the container ID from a cgroup path, supporting multiple prefixes.
+/// Helpers
+
+/// Helper function to extract the container ID from a cgroup path, supporting multiple prefixes.
+/// Supports Docker, Containerd, CRI-O, Docker cgroup V1.
+/// Used in try_resolve_docker function
 fn extract_container_id_from_path(cgroup_path: &str) -> Option<String> {
     let parts: Vec<&str> = cgroup_path.split('/').collect();
 
@@ -179,83 +224,25 @@ fn extract_container_id_from_path(cgroup_path: &str) -> Option<String> {
     None
 }
 
-/// Resolve a Docker container name by reading `config.v2.json`.
-///
-// TODO: Does this work on macOs?
+/// Resolve a Docker container name by reading config.v2.json.
 fn resolve_docker_name(container_id: &str) -> Option<String> {
+    // TODO: Does this work on macOs?
     let path = format!("/var/lib/docker/containers/{}/config.v2.json", container_id);
     let json_str = fs::read_to_string(&path).ok()?;
     let parsed: serde_json::Value = serde_json::from_str(&json_str).ok()?;
-    let mut image_name = parsed
+    let image_name = parsed
         .get("Config")?
         .get("Image")?
         .as_str()?
         .trim_start_matches('/');
     if image_name.is_empty() {
-        image_name = parsed
-            .get("Config")?
-            .get("WorkingDir")?
-            .as_str()?
-            .trim_start_matches('/'); // fallback if the image_name is empty
+        return None; // if images is empty returns None
     }
 
     Some(image_name.to_string())
 }
 
-
-fn resolve_k8s_name(container_id: &str) -> Option<String> {
-    // pass a container_id and returns the object meta infos:
-    /* pub struct ObjectMeta {
-
-        pub annotations: Option<BTreeMap<String, String>>,
-        pub creation_timestamp: Option<Time>,
-        pub deletion_grace_period_seconds: Option<i64>,
-        pub deletion_timestamp: Option<Time>,
-        pub finalizers: Option<Vec<String>>,
-        pub generate_name: Option<String>,
-        pub generation: Option<i64>,
-        pub labels: Option<BTreeMap<String, String>>,
-        pub managed_fields: Option<Vec<ManagedFieldsEntry>>,
-        pub name: Option<String>,
-        pub namespace: Option<String>,
-        pub owner_references: Option<Vec<OwnerReference>>,
-        pub resource_version: Option<String>,
-        pub self_link: Option<String>,
-        pub uid: Option<String>,
-    } */
-
-    todo!()
-}
-
-
-async fn query_all_pods() -> Result<ObjectList<Pod>, Error> {
-    let client = Client::try_default()
-        .await
-        .expect("Cannot connect to kubernetes client");
-    let pods: Api<Pod> = Api::all(client);
-    let lp = kube::api::ListParams::default(); // default list params
-    let pod_list = pods
-        .list(&lp)
-        .await
-        .expect("An error occured during the pod list extraction");
-
-    Ok(pod_list)
-}
-
-async fn get_pod_info() -> Result<HashMap<String, String>, Error> {
-    let all_pods = query_all_pods().await?;
-
-    let mut service_map = HashMap::<String, String>::new();
-
-    for pod in all_pods {
-        if let (Some(name), Some(uid)) = (pod.metadata.name, pod.metadata.uid) {
-            service_map.insert(uid, name);
-        }
-    } // insert the pod name and uid from the KubeAPI
-
-    Ok(service_map)
-}
-
+/// Helper function to extract the pod name, called 'target' from a vector of splits ['','','']
 fn extract_target_from_splits(splits: Vec<&str>, target: &str) -> Result<usize, Error> {
     for (index, split) in splits.iter().enumerate() {
         // find the split that contains the word 'pod'
@@ -267,8 +254,7 @@ fn extract_target_from_splits(splits: Vec<&str>, target: &str) -> Result<usize, 
     Err(Error::msg("'-pod' word not found in split"))
 }
 
-
-fn extract_pod_uid(cgroup_path: String) -> Result<String, Error> {
+fn extract_pod_uid(cgroup_path: String) -> Option<String> {
     // example of cgroup path:
     // /sys/fs/cgroup/kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-besteffort.slice/kubelet-kubepods-besteffort-pod93580201_87d5_44e6_9779_f6153ca17637.slice
     // or
@@ -278,23 +264,78 @@ fn extract_pod_uid(cgroup_path: String) -> Result<String, Error> {
     let splits: Vec<&str> = cgroup_path.split("/").collect();
     debug!("Debugging splits: {:?}", &splits);
 
-    let index = extract_target_from_splits(splits.clone(), "-pod")?;
+    let index = extract_target_from_splits(splits.clone(), "-pod").ok();
 
-    let pod_split = splits[index]
-        .trim_start_matches("kubelet-kubepods-besteffort-")
-        .trim_start_matches("kubelet-kubepods-burstable-")
-        .trim_start_matches("kubepods-besteffort-")
-        .trim_start_matches("kubepods-burstable-");
+    match index {
+        Some(idx) => {
+            let pod_split = splits[idx]
+                .trim_start_matches("kubelet-kubepods-besteffort-")
+                .trim_start_matches("kubelet-kubepods-burstable-")
+                .trim_start_matches("kubepods-besteffort-")
+                .trim_start_matches("kubepods-burstable-");
 
-    let uid_ = pod_split
-        .trim_start_matches("pod")
-        .trim_end_matches(".slice"); //return uids with underscore (_) [ex.dd3a1c6b_af40_41b1_8e1c_9e31fe8d96cb]
+            let uid_ = pod_split
+                .trim_start_matches("pod")
+                .trim_end_matches(".slice"); //return uids with underscore (_) [ex.dd3a1c6b_af40_41b1_8e1c_9e31fe8d96cb]
 
-    let uid = uid_.replace("_", "-");
-    Ok(uid.to_string())
+            let uid = Some(uid_.replace("_", "-"));
+            uid
+        }
+        None => {
+            debug!("Index returned a value of None");
+            None
+        }
+    }
 }
 
+/// Detect if the host is running cgroup v2.
+/// On cgroup v2 the file /sys/fs/cgroup/cgroup.controllers exists; on v1 it
+/// does not (the controllers are split across /sys/fs/cgroup/<controller>).
+/// this is a way to detect if we can attach the try_resolve_k8s functions
+fn detect_cgroup_v2() -> bool {
+    Path::new("/host/sys/fs/cgroup")
+        .join("cgroup.controllers")
+        .is_file()
+}
 
+/// Scans /sys/fs/cgroup recursively and return the path of the directory that
+/// matches cgroup_id. This lookup is guaranteed because of the structure of the cgroup v2 in linux
+fn find_cgroup_path_by_id(cgroup_id: u64) -> Option<PathBuf> {
+    let root = Path::new("/host/sys/fs/cgroup");
+    let mut stack = vec![root.to_path_buf()];
+
+    while let Some(dir) = stack.pop() {
+        let meta = match fs::metadata(&dir) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+
+        if meta.ino() == cgroup_id {
+            return Some(dir);
+        }
+
+        if let Ok(entries) = fs::read_dir(&dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    stack.push(path);
+                }
+            }
+        }
+    }
+
+    None
+}
+
+fn get_cgroup_info(tgid: u32) -> Option<String> {
+    let cgroup_info = match fs::read_to_string(format!("/proc/{}/cgroup", tgid)) {
+        Ok(s) => return Some(s),
+        Err(e) => {
+            debug!("Cannot read /proc/{}/cgroup: {}", tgid, e);
+            return None;
+        }
+    };
+}
 
 #[cfg(test)]
 mod tests {
@@ -353,4 +394,5 @@ mod tests {
 
         assert_eq!(docker_container_name, Some("busybox:latest".to_string()))
     }
+    // TODO: missing tests for extract_pod_uid, extract_target_from_splits, try_resolve_docker, try_resolve_k8s, enrich.
 }

--- a/core/common/src/metadata.rs
+++ b/core/common/src/metadata.rs
@@ -1,4 +1,11 @@
+use std::collections::HashMap;
 use std::fs;
+use anyhow::Error;
+use k8s_openapi::api::core::v1::Pod;
+use kube::api::ObjectList;
+use kube::{Api, Client};
+use tracing::debug;
+
 
 /// Detected container runtime.
 #[derive(Debug, Clone, PartialEq)]
@@ -47,11 +54,11 @@ impl Metadata {
     /// 4. If Docker is not found, attempts K8s lookup.
     pub fn enrich(&mut self) {
         self.try_resolve_docker();
-        // K8s lookup will be enabled later with an LRU cache.
+        self.try_resolve_k8s();
     }
 
     /// Docker resolution via local filesystem.
-    ///
+    /// This part is triggered when the container is already detected
     // TODO: this is working for Linux, can anyone check if this works on macOs systems ?
     fn try_resolve_docker(&mut self) {
         let Some(tgid) = self.tgid else { return };
@@ -84,17 +91,62 @@ impl Metadata {
             // Step 3: resolve container name from Docker metadata JSON
             match resolve_docker_name(&id) {
                 Some(name) => self.container_name = Some(name),
-                None => self.container_name = Some("null".to_string()),
+                None => {
+                    self.container_name =
+                        Some(self.container_id.clone()).expect("Cannot resolve container name")
+                } // fallback to the container_id if the system cannot resolve the name after the 2 steps
             }
         }
     }
 
-    /// Manual enrichment from Kubernetes (for external use, e.g. identity service).
-    pub fn enrich_from_k8s(&mut self, pod_name: impl Into<String>, namespace: impl Into<String>) {
-        self.runtime = ContainerRuntime::Kubernetes;
-        self.pod_name = Some(pod_name.into());
-        self.namespace = Some(namespace.into());
+    fn try_resolve_k8s(&mut self){
+        let Some(tgid) = self.tgid else { return };
+
+        // Step 1: read the cgroup path from procfs
+        let cgroup_info = match fs::read_to_string(format!("/proc/{}/cgroup", tgid)) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::debug!("Cannot read /proc/{}/cgroup: {}", tgid, e);
+                return;
+            }
+        };
+
+        // Extract the actual path from the cgroup file (format: hierarchy:id:path)
+        let cgroup_path = cgroup_info
+            .lines()
+            .filter_map(|line| line.split(':').nth(2))
+            .next()
+            .unwrap_or("");
+
+        if cgroup_path.is_empty() {
+            return;
+        }
+
+        // Step 2: extract container ID from the path
+        if let Some(id) = extract_container_id_from_path(cgroup_path) {
+            self.container_id = Some(id.clone());
+            self.runtime = ContainerRuntime::Kubernetes;
+
+            // Step 3: resolve container name from Docker metadata JSON
+            match resolve_k8s_name(&id) {
+                Some(name) => self.container_name = Some(name),
+                None => {
+                    self.container_name =
+                        Some(self.container_id.clone()).expect("Cannot resolve container name from k8s api ")
+                } // fallback to the container_id if the system cannot resolve the name after the 2 steps
+            }
+        }
+
+        //Step 3: call the k8s API to solve the container nam e
     }
+
+    // TODO: dead code 
+    // Enrichment from Kubernetes (for external use, e.g. identity service).
+    //pub fn enrich_from_k8s(&mut self, pod_name: impl Into<String>, namespace: impl Into<String>) {
+    //    self.runtime = ContainerRuntime::Kubernetes;
+    //    self.pod_name = Some(pod_name.into());
+    //    self.namespace = Some(namespace.into());
+    //}
 }
 
 /// Extract the container ID from a cgroup path, supporting multiple prefixes.
@@ -134,13 +186,115 @@ fn resolve_docker_name(container_id: &str) -> Option<String> {
     let path = format!("/var/lib/docker/containers/{}/config.v2.json", container_id);
     let json_str = fs::read_to_string(&path).ok()?;
     let parsed: serde_json::Value = serde_json::from_str(&json_str).ok()?;
-    let image_name = parsed
+    let mut image_name = parsed
         .get("Config")?
         .get("Image")?
         .as_str()?
         .trim_start_matches('/');
+    if image_name.is_empty() {
+        image_name = parsed
+            .get("Config")?
+            .get("WorkingDir")?
+            .as_str()?
+            .trim_start_matches('/'); // fallback if the image_name is empty
+    }
+
     Some(image_name.to_string())
 }
+
+
+fn resolve_k8s_name(container_id: &str) -> Option<String> {
+    // pass a container_id and returns the object meta infos:
+    /* pub struct ObjectMeta {
+
+        pub annotations: Option<BTreeMap<String, String>>,
+        pub creation_timestamp: Option<Time>,
+        pub deletion_grace_period_seconds: Option<i64>,
+        pub deletion_timestamp: Option<Time>,
+        pub finalizers: Option<Vec<String>>,
+        pub generate_name: Option<String>,
+        pub generation: Option<i64>,
+        pub labels: Option<BTreeMap<String, String>>,
+        pub managed_fields: Option<Vec<ManagedFieldsEntry>>,
+        pub name: Option<String>,
+        pub namespace: Option<String>,
+        pub owner_references: Option<Vec<OwnerReference>>,
+        pub resource_version: Option<String>,
+        pub self_link: Option<String>,
+        pub uid: Option<String>,
+    } */
+
+    todo!()
+}
+
+
+async fn query_all_pods() -> Result<ObjectList<Pod>, Error> {
+    let client = Client::try_default()
+        .await
+        .expect("Cannot connect to kubernetes client");
+    let pods: Api<Pod> = Api::all(client);
+    let lp = kube::api::ListParams::default(); // default list params
+    let pod_list = pods
+        .list(&lp)
+        .await
+        .expect("An error occured during the pod list extraction");
+
+    Ok(pod_list)
+}
+
+async fn get_pod_info() -> Result<HashMap<String, String>, Error> {
+    let all_pods = query_all_pods().await?;
+
+    let mut service_map = HashMap::<String, String>::new();
+
+    for pod in all_pods {
+        if let (Some(name), Some(uid)) = (pod.metadata.name, pod.metadata.uid) {
+            service_map.insert(uid, name);
+        }
+    } // insert the pod name and uid from the KubeAPI
+
+    Ok(service_map)
+}
+
+fn extract_target_from_splits(splits: Vec<&str>, target: &str) -> Result<usize, Error> {
+    for (index, split) in splits.iter().enumerate() {
+        // find the split that contains the word 'pod'
+        if split.contains(target) {
+            debug!("Target index; {}", index);
+            return Ok(index);
+        }
+    }
+    Err(Error::msg("'-pod' word not found in split"))
+}
+
+
+fn extract_pod_uid(cgroup_path: String) -> Result<String, Error> {
+    // example of cgroup path:
+    // /sys/fs/cgroup/kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-besteffort.slice/kubelet-kubepods-besteffort-pod93580201_87d5_44e6_9779_f6153ca17637.slice
+    // or
+    // /sys/fs/cgroup/kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-burstable.slice/kubelet-kubepods-burstable-poddd3a1c6b_af40_41b1_8e1c_9e31fe8d96cb.slice
+
+    // split the path by "/"
+    let splits: Vec<&str> = cgroup_path.split("/").collect();
+    debug!("Debugging splits: {:?}", &splits);
+
+    let index = extract_target_from_splits(splits.clone(), "-pod")?;
+
+    let pod_split = splits[index]
+        .trim_start_matches("kubelet-kubepods-besteffort-")
+        .trim_start_matches("kubelet-kubepods-burstable-")
+        .trim_start_matches("kubepods-besteffort-")
+        .trim_start_matches("kubepods-burstable-");
+
+    let uid_ = pod_split
+        .trim_start_matches("pod")
+        .trim_end_matches(".slice"); //return uids with underscore (_) [ex.dd3a1c6b_af40_41b1_8e1c_9e31fe8d96cb]
+
+    let uid = uid_.replace("_", "-");
+    Ok(uid.to_string())
+}
+
+
 
 #[cfg(test)]
 mod tests {
@@ -194,7 +348,7 @@ mod tests {
         println!("{}", &container_id);
         let docker_container_name = match resolve_docker_name(&container_id) {
             Some(name) => Some(name),
-            None => Some("null".to_string()),
+            None => None,
         };
 
         assert_eq!(docker_container_name, Some("busybox:latest".to_string()))

--- a/core/common/src/metadata.rs
+++ b/core/common/src/metadata.rs
@@ -1,4 +1,5 @@
 use anyhow::Error;
+use kube::Client;
 use std::fs;
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
@@ -58,19 +59,25 @@ impl Metadata {
     pub async fn enrich(&mut self, cache: &Arc<RwLock<ServiceCache>>) {
         if let Some(cgid) = self.cgroup_id
             && cgid != 0
-            && detect_cgroup_v2()
             && self.try_resolve_from_cgroup_id(cgid, cache).await
         {
             return;
         } else {
-            debug!("cgroup_v2 not detected. Using cgroup v1");
-            self.try_resolve_docker();
+            debug!("An error occured during cgroup_id resolution.Trying with docker and tgid");
         }
-        self.try_resolve_k8s(cache).await;
+        if let Some(tgid) = self.tgid
+            && self.try_resolve_docker(tgid, cache).await
+        {
+            return;
+        } else {
+            debug!("Cannot resolve tgid with Docker");
+        }
     }
 
     /// Resolve pod/container from a kernel cgroup_id by walking /sys/fs/cgroup (v2).
     /// Returns true if resolution succeeded (pod_uid extracted), false to allow caller fallback.
+    ///
+    /// only for k8s
     async fn try_resolve_from_cgroup_id(
         &mut self,
         cgroup_id: u64,
@@ -84,43 +91,40 @@ impl Metadata {
             return false;
         };
 
-        if let Some(id) = extract_pod_uid(cgroup_path.to_string_lossy().to_string()) {
+        if let Some(id) = extract_pod_uid(cgroup_path.to_string_lossy().to_string())
+            && Client::try_default().await.is_ok()
+        {
             self.container_id = Some(id.clone());
+            debug!(
+                "Resolving container id {:?} using the pod UID",
+                self.container_id
+            );
             self.runtime = ContainerRuntime::Kubernetes;
 
             // get pod from cache
             // acquire cache lock
             let cache_lock = cache.read().await;
             match cache_lock.get_from_cache(&id).await {
-                Some(name) => self.pod_name = Some(name),
+                Some(name) => {
+                    self.pod_name = Some(name);
+                    return true;
+                }
                 None => {
-                    // fallback to the container_id if the k8s API cannot resolve the name
-                    self.pod_name = Some(id.clone());
+                    return false;
                 }
             }
-            return true;
         }
-
-        // not a k8s pod cgroup — try docker/containerd/crio container id
-        if let Some(id) = extract_container_id_from_path(&cgroup_path.to_string_lossy()) {
-            self.container_id = Some(id.clone());
-            self.runtime = ContainerRuntime::Docker;
-            match resolve_docker_name(&id) {
-                Some(name) => self.container_name = Some(name),
-                None => self.container_name = self.container_id.clone(),
-            }
-            return true;
-        }
-
         false
     }
 
     /// Docker resolution via local filesystem.
     /// This part is triggered when the container is already detected
     // TODO: this is working for Linux, can anyone check if this works on macOs systems ?
-    fn try_resolve_docker(&mut self) {
-        let Some(tgid) = self.tgid else { return };
-
+    pub async fn try_resolve_docker(
+        &mut self,
+        tgid: u32,
+        cache: &Arc<RwLock<ServiceCache>>,
+    ) -> bool {
         // Step 1: read the cgroup path from procfs
         if let Some(cgroup_info) = get_cgroup_info(tgid) {
             // Extract the actual path from the cgroup file (format: hierarchy:id:path)
@@ -132,61 +136,32 @@ impl Metadata {
 
             if cgroup_path.is_empty() {
                 info!("cgroup_path is empty");
-                return;
+                return false;
             }
 
             // Step 2: extract container ID from the path
-            if let Some(id) = extract_container_id_from_path(cgroup_path) {
+            if let Some(id) = extract_container_id_from_path(&cgroup_path.to_string()) {
                 self.container_id = Some(id.clone());
+                debug!(
+                    "Resolving container id {:?} using the docker fs",
+                    self.container_id
+                );
                 self.runtime = ContainerRuntime::Docker;
 
-                // Step 3: resolve container name from Docker metadata JSON
-                match resolve_docker_name(&id) {
+                let cache_lock = cache.read().await;
+                match cache_lock.get_from_cache(&id).await {
                     Some(name) => self.container_name = Some(name),
-                    None => {
-                        self.container_name = self.container_id.clone(); // fallback to the container_id if the system cannot resolve the name after the 2 steps
-                    }
+                    None => match resolve_docker_name(&id) {
+                        Some(name) => {
+                            self.container_name = Some(name);
+                            return true;
+                        }
+                        None => return false,
+                    },
                 }
             }
         };
-    }
-
-    async fn try_resolve_k8s(&mut self, cache: &Arc<RwLock<ServiceCache>>) {
-        let Some(tgid) = self.tgid else { return };
-
-        // Step 1: read the cgroup path from procfs
-        if let Some(cgroup_info) = get_cgroup_info(tgid) {
-            // Extract the actual path from the cgroup file (format: hierarchy:id:path)
-            let cgroup_path = cgroup_info
-                .lines()
-                .filter_map(|line| line.split(':').nth(2))
-                .next()
-                .unwrap_or("");
-
-            if cgroup_path.is_empty() {
-                info!("cgroup_path is empty");
-                return;
-            }
-
-            // Step 2: extract container ID from the path
-            if let Some(id) = extract_pod_uid(cgroup_path.to_string()) {
-                self.container_id = Some(id.clone());
-                self.runtime = ContainerRuntime::Kubernetes;
-
-                // Step 3: resolve container name from the k8s API
-
-                //acquire cache lock
-                let cache_lock = cache.read().await;
-
-                match cache_lock.get_from_cache(&id).await {
-                    Some(name) => self.pod_name = Some(name),
-                    None => {
-                        // fallback to the container_id if the k8s API cannot resolve the name
-                        self.pod_name = Some(id.clone());
-                    }
-                }
-            }
-        }
+        false
     }
 }
 
@@ -286,16 +261,6 @@ fn extract_pod_uid(cgroup_path: String) -> Option<String> {
             None
         }
     }
-}
-
-/// Detect if the host is running cgroup v2.
-/// On cgroup v2 the file /sys/fs/cgroup/cgroup.controllers exists; on v1 it
-/// does not (the controllers are split across /sys/fs/cgroup/<controller>).
-/// this is a way to detect if we can attach the try_resolve_k8s functions
-fn detect_cgroup_v2() -> bool {
-    Path::new("/host/sys/fs/cgroup")
-        .join("cgroup.controllers")
-        .is_file()
 }
 
 /// Scans /sys/fs/cgroup recursively and return the path of the directory that

--- a/core/common/src/otel_metrics.rs
+++ b/core/common/src/otel_metrics.rs
@@ -18,6 +18,7 @@ use crate::metadata::{Metadata};
 use crate::semantic::Semantic;
 use opentelemetry::KeyValue;
 use opentelemetry::metrics::{Counter, Gauge, Histogram, Meter};
+use tracing::debug;
 
 pub struct Metrics {
     /// Total number of eBPF events processed across all perf buffers.
@@ -242,6 +243,7 @@ impl Metrics {
     /// and `sk_err` as gauges.
     pub fn record_packet_loss_metrics(&self, m: &PacketLossMetrics, metadata: &Metadata) {
         let attrs = &self.build_attrs(metadata);
+        debug!("Building attributes for packet loss metrics. Attributes: {:?}",attrs);
 
         self.events_total.add(1, attrs);
         self.socket_events_total.add(1, attrs);
@@ -255,6 +257,7 @@ impl Metrics {
     /// histogram.
     pub fn record_timestamp_metrics(&self, m: &TimeStampMetrics, metadata: &Metadata) {
         let attrs = &self.build_attrs(metadata);
+        debug!("Building attributes for latency metrics. Attributes: {:?}",attrs);
 
         self.events_total.add(1, attrs);
         self.tcp_latency_us.record(m.delta_us, attrs);
@@ -264,6 +267,7 @@ impl Metrics {
     pub fn record_cpu_bytes_alloc(&self, m: &CpuFrequency, metadata: &Metadata) {
         let bytes_allocated = m.bytes_alloc;
         let attrs = &self.build_attrs(metadata);
+        debug!("Building attributes for CPU metrics. Attributes: {:?}",attrs);
 
         self.cpu_bytes_alloc_events_total.add(1, attrs);
         self.cpu_bytes_alloc.record(bytes_allocated as i64, attrs);
@@ -277,6 +281,7 @@ impl Metrics {
     /// events.
     pub fn record_enter_mem_alloc(&self, m: &MemAlloc, metadata: &Metadata) {
         let attrs = &self.build_attrs(metadata);
+        debug!("Building attributes for Mem alloc metrics. Attributes: {:?}",attrs);
 
         self.events_total.add(1, attrs);
         self.mem_alloc_events_total.add(1, attrs);
@@ -290,7 +295,8 @@ impl Metrics {
     /// histogram.
     pub fn record_sched_stat_wait(&self, m: &SchedStatWait, metadata: &Metadata) {
         let attrs = &self.build_attrs(metadata);
-
+        debug!("Building attributes for Sched stat wait metrics. Attributes: {:?}",attrs);
+        
         self.events_total.add(1, attrs);
         self.sched_stat_wait.record(m.delay as i64, attrs);
         self.sched_stat_wait_distribution.record(m.delay, attrs);
@@ -304,6 +310,9 @@ impl Metrics {
     pub fn record_sched_stat_runtime(&self, m: &SchedStatRuntime, metadata: &Metadata) {
         let attrs = &self.build_attrs(metadata);
 
+        debug!("Building attributes for sched stat runtime metrics. Attributes: {:?}",attrs);
+
+
         self.events_total.add(1, attrs);
         self.sched_stat_runtime.record(m.runtime as i64, attrs);
         self.sched_stat_runtime_distribution
@@ -316,6 +325,9 @@ impl Metrics {
     /// `cpu_id`. Events are only emitted by eBPF when the state changes.
     pub fn record_cpu_idle(&self, m: &CpuIdle, metadata: &Metadata) {
         let mut attrs = self.build_attrs(metadata);
+
+        debug!("Building attributes for record cpu idle metrics. Attributes: {:?}",attrs);
+
         attrs.push(KeyValue::new("cpu_id", m.cpu_id as i64));
 
         self.events_total.add(1, &attrs);
@@ -324,12 +336,16 @@ impl Metrics {
 
     pub fn record_ssl_read_bytes(&self, m: &SslEvent, metadata: &Metadata) {
         let attrs = self.build_attrs(metadata);
+        debug!("Building attributes for SSL read metrics. Attributes: {:?}",attrs);
+
 
         self.events_total.add(1, &attrs);
         self.ssl_read_bytes.record(m.size as i64, &attrs);
     }
     pub fn record_ssl_write_bytes(&self, m: &SslEvent, metadata: &Metadata) {
         let attrs = self.build_attrs(metadata);
+        debug!("Building attributes for SSL write metrics. Attributes: {:?}",attrs);
+
 
         self.events_total.add(1, &attrs);
         self.ssl_write_bytes.record(m.size as i64, &attrs);

--- a/core/common/src/otel_metrics.rs
+++ b/core/common/src/otel_metrics.rs
@@ -14,7 +14,7 @@ use crate::buffer_type::{
     CpuFrequency, CpuIdle, MemAlloc, PacketLossMetrics, SchedStatRuntime, SchedStatWait, SslEvent,
     TimeStampMetrics,
 };
-use crate::metadata::{ContainerRuntime, Metadata};
+use crate::metadata::{Metadata};
 use crate::semantic::Semantic;
 use opentelemetry::KeyValue;
 use opentelemetry::metrics::{Counter, Gauge, Histogram, Meter};
@@ -212,13 +212,11 @@ impl Metrics {
         attrs.push(KeyValue::new("command", metadata.command.clone()));
 
         // container metadata
-        attrs.push(KeyValue::new(
-            "container.name",
-            match &metadata.container_name {
-                Some(name) => name.clone(),
-                None => "null".to_string(),
-            },
-        ));
+
+        match &metadata.container_name {
+            Some(name) => attrs.push(KeyValue::new("container.name", name.clone())),
+            None => (), // process is not associated with a container, the cgroup path does not contain an container id
+        }
 
         if let Some(ref id) = metadata.container_id {
             attrs.push(KeyValue::new("container.id", id.clone()));

--- a/core/common/src/service_cache.rs
+++ b/core/common/src/service_cache.rs
@@ -1,0 +1,71 @@
+use anyhow::Error;
+use k8s_openapi::api::core::v1::Pod;
+use kube::api::ObjectList;
+use kube::{Api, Client};
+use std::collections::HashMap;
+use tracing::debug;
+
+#[derive(Clone, Debug)]
+pub struct ServiceCache {
+    // service_map should maitain the Option Type. Since Option type can be also None
+    // it's used to deal all the cases
+    pub service_map: Option<HashMap<String, String>>,
+}
+impl ServiceCache {
+    pub fn init(&mut self) {
+        self.service_map = Some(HashMap::<String, String>::new());
+    }
+
+    /// Helper function to query all pods form the Kubernetes API
+    pub async fn query_all_pods_from_kubeapi(&mut self) -> Result<ObjectList<Pod>, Error> {
+        debug!("Connecting to kubernetes client");
+        let client = Client::try_default().await?;
+        debug!("Querying all the pods");
+        let pods: Api<Pod> = Api::all(client);
+        let lp = kube::api::ListParams::default(); // default list params
+        let pod_list = pods.list(&lp).await?;
+
+        Ok(pod_list)
+    }
+
+    /// Helper function to populate and mantain a cache service map
+    pub async fn populate_map_with_pod_info(&mut self) -> Result<(), Error> {
+        let all_pods = self.query_all_pods_from_kubeapi().await?;
+
+        debug!("Querying and updating all the pods");
+        for pod in all_pods {
+            if let (Some(name), Some(uid)) = (pod.metadata.name, pod.metadata.uid) {
+                if let Some(map) = self.service_map.as_mut() {
+                    map.insert(uid, name);
+                }
+            }
+        } // insert the pod name and uid from the KubeAPI
+        Ok(())
+    }
+    pub async fn get_from_cache(&self, container_id: &str) -> Option<String> {
+        // pass a container_id and returns the object meta infos:
+        /* pub struct ObjectMeta {
+            pub annotations: Option<BTreeMap<String, String>>,
+            pub creation_timestamp: Option<Time>,
+            pub deletion_grace_period_seconds: Option<i64>,
+            pub deletion_timestamp: Option<Time>,
+            pub finalizers: Option<Vec<String>>,
+            pub generate_name: Option<String>,
+            pub generation: Option<i64>,
+            pub labels: Option<BTreeMap<String, String>>,
+            pub managed_fields: Option<Vec<ManagedFieldsEntry>>,
+            pub name: Option<String>,
+            pub namespace: Option<String>,
+            pub owner_references: Option<Vec<OwnerReference>>,
+            pub resource_version: Option<String>,
+            pub self_link: Option<String>,
+            pub uid: Option<String>,
+        } */
+
+        if let Some(map) = self.service_map.as_ref() {
+            map.get(container_id).cloned() // cache hit 
+        } else {
+            None
+        }
+    }
+}

--- a/core/common/src/service_cache.rs
+++ b/core/common/src/service_cache.rs
@@ -30,16 +30,54 @@ impl ServiceCache {
 
     /// Helper function to populate and mantain a cache service map
     pub async fn populate_map_with_pod_info(&mut self) -> Result<(), Error> {
-        let all_pods = self.query_all_pods_from_kubeapi().await?;
+        if Client::try_default().await.is_ok() {
+            let all_pods = self.query_all_pods_from_kubeapi().await?;
 
-        debug!("Querying and updating all the pods");
-        for pod in all_pods {
-            if let (Some(name), Some(uid)) = (pod.metadata.name, pod.metadata.uid) {
-                if let Some(map) = self.service_map.as_mut() {
-                    map.insert(uid, name);
+            debug!("Querying and updating all the pods");
+            for pod in all_pods {
+                if let (Some(name), Some(uid), Some(annotations)) = (
+                    pod.metadata.name,
+                    pod.metadata.uid,
+                    pod.metadata.annotations,
+                ) {
+                    // docs from kubernetes
+                    // Annotations is an unstructured key value map stored with a resource that
+                    // may be set by external tools to store and retrieve arbitrary metadata.
+                    // They are not queryable and should be preserved when modifying objects.
+                    //More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+
+                    if let Some(map) = self.service_map.as_mut() {
+
+                        // static pods are managed by the kubelet itself instead all the other pods 
+                        // are managed by controllers without the need of the API server
+                        // the kubelet mirrors the static pods but the UID does not match the real signature of the pod (verified)
+                        // so the algorithm check if the pod is static by checking if the annotations contains the word 'file' or 'http' 
+                        // reference for the labels: https://kubernetes.io/docs/reference/labels-annotations-taints/
+                        // and copies the config.hash (aka the signature of the static pod) into the service cache instead of the UID
+
+                        // more about static pods: https://medium.com/@iamsteffinissac/mastering-static-pods-in-kubernetes-bootstrapping-troubleshooting-mirror-pods-advanced-update-a35a5f95e329
+
+
+                        let is_static_pod = annotations
+                            .get("kubernetes.io/config.source")
+                            .is_some_and(|a| a == "file" || a== "http");
+
+                        let key = if is_static_pod {
+                            annotations
+                                .get("kubernetes.io/config.hash")
+                                .cloned()
+                                .unwrap_or(uid)
+                        } else {
+                            uid
+                        };
+                        map.insert(key, name);
+                    }
                 }
-            }
-        } // insert the pod name and uid from the KubeAPI
+            } // insert the pod name and uid from the KubeAPI
+        } else {
+            debug!("Kubernetes environment not available");
+        }
+
         Ok(())
     }
     pub async fn get_from_cache(&self, container_id: &str) -> Option<String> {

--- a/core/src/components/conntracker/build-conntracker.sh
+++ b/core/src/components/conntracker/build-conntracker.sh
@@ -13,7 +13,9 @@ if ! command -v bindgen &> /dev/null; then
     export PATH="$HOME/.cargo/bin:$PATH" #add the ./cargo/bin directory to the PATH env variable
 fi
 
-bindgen vmlinux.h -o src/bindings.rs --use-core --allowlist-type 'sk_buff' --opaque-type 'ieee80211_sband_iftype_data'
+bindgen --use-core --no-layout-tests \
+    --allowlist-type 'sk_buff' \
+    vmlinux.h -o src/bindings.rs
 
 cargo +nightly build -Z build-std=core --target bpfel-unknown-none --release --bin conntracker
 

--- a/core/src/components/identity/Dockerfile
+++ b/core/src/components/identity/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN cargo install --locked bindgen-cli
-RUN cargo install --locked bpf-linker
+RUN cargo install --locked bpf-linker@0.10.4
 RUN rustup toolchain install nightly --component rust-src
 
 WORKDIR /usr/src/app

--- a/core/src/components/metrics/Cargo.toml
+++ b/core/src/components/metrics/Cargo.toml
@@ -26,7 +26,7 @@ tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 libc = "0.2.172"
 bytemuck = "1.23.0"
-cortexbrain-common = { version = "0.1.2", features = [
+cortexbrain-common = { path = "../../../common/", features = [
     "map-handlers",
     "program-handlers",
     "buffer-reader",

--- a/core/src/components/metrics/Cargo.toml
+++ b/core/src/components/metrics/Cargo.toml
@@ -20,6 +20,7 @@ tokio = { version = "1.48.0", features = [
     "fs",
     "signal",
     "rt-multi-thread",
+    "sync"
 ] }
 anyhow = "1.0"
 tracing = "0.1.41"

--- a/core/src/components/metrics/Dockerfile
+++ b/core/src/components/metrics/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN cargo install --locked bindgen-cli
-RUN cargo install --locked bpf-linker
+RUN cargo install --locked bpf-linker@0.10.4
 RUN rustup toolchain install nightly --component rust-src
 
 WORKDIR /usr/src/app

--- a/core/src/components/metrics/src/helpers.rs
+++ b/core/src/components/metrics/src/helpers.rs
@@ -6,12 +6,14 @@ use opentelemetry::metrics::Meter;
 use std::env;
 use std::path::Path;
 use std::sync::Arc;
-use tokio::signal;
+use std::time::Duration;
+use tokio::{signal, time};
 use tracing::{error, info};
 
 use cortexbrain_common::constants;
 use cortexbrain_common::consumer::{Consumer, read_perf_buffer};
 use cortexbrain_common::otel_metrics::Metrics;
+use cortexbrain_common::service_cache::ServiceCache;
 
 /// Locate the OpenSSL shared library used for the SSL uprobes.
 ///
@@ -146,11 +148,33 @@ pub async fn event_listener(bpf_maps: BpfMapsData, meter: Meter) -> Result<(), a
     let ssl_events_buffers = BufferSize::SslEvents.set_buffer();
 
     let metrics = Arc::new(Metrics::new(&meter));
+    let mut cache_obj = ServiceCache { service_map: None };
+    cache_obj.init(); //init cache
+    cache_obj.populate_map_with_pod_info().await?; // populate cache with a first scan of the services 
+    let cache = Arc::new(tokio::sync::RwLock::new(cache_obj));
 
     info!("Starting event listener tasks...");
 
+    let cache_refresher = Arc::clone(&cache);
+    let cache_handle = {
+        tokio::spawn(async move {
+            let mut interval = time::interval(Duration::from_secs(60));
+            // every 60 seconds the cache auto updates and qu
+            loop {
+                interval.tick().await;
+                // scan the cache once again to check if we need to update it
+                // acquire cache write lock
+                let mut cache_lock = cache_refresher.write().await;
+                if let Err(e) = cache_lock.populate_map_with_pod_info().await {
+                    error!("cache refresh fail. {}", e);
+                };
+            }
+        })
+    };
+
     let net_metrics_handle = {
         let metrics = Arc::clone(&metrics);
+        let service_cache = Arc::clone(&cache);
         let mut array_buffers = net_perf_buffer;
         let mut buffers = net_metrics_buffers;
         tokio::spawn(async move {
@@ -159,6 +183,7 @@ pub async fn event_listener(bpf_maps: BpfMapsData, meter: Meter) -> Result<(), a
                 buffers,
                 Consumer::PacketLossMetrics,
                 Some(metrics),
+                Some(service_cache),
             )
             .await;
         })
@@ -166,6 +191,7 @@ pub async fn event_listener(bpf_maps: BpfMapsData, meter: Meter) -> Result<(), a
 
     let time_stamp_handle = {
         let metrics = Arc::clone(&metrics);
+        let service_cache = Arc::clone(&cache);
         let mut array_buffers = time_stamp_events_perf_buffer;
         let mut buffers = time_stamp_events_buffers;
         tokio::spawn(async move {
@@ -174,6 +200,7 @@ pub async fn event_listener(bpf_maps: BpfMapsData, meter: Meter) -> Result<(), a
                 buffers,
                 Consumer::TimeStampMetrics,
                 Some(metrics),
+                Some(service_cache),
             )
             .await;
         })
@@ -181,6 +208,7 @@ pub async fn event_listener(bpf_maps: BpfMapsData, meter: Meter) -> Result<(), a
 
     let cpu_frequency_metrics = {
         let metrics = Arc::clone(&metrics);
+        let service_cache = Arc::clone(&cache);
         let mut array_buffers = cpu_frequency_perf_buffer;
         let mut buffers = cpu_frequency_events_buffers;
         tokio::spawn(async move {
@@ -189,6 +217,7 @@ pub async fn event_listener(bpf_maps: BpfMapsData, meter: Meter) -> Result<(), a
                 buffers,
                 Consumer::CpuFrequency,
                 Some(metrics),
+                Some(service_cache),
             )
             .await;
         })
@@ -196,24 +225,42 @@ pub async fn event_listener(bpf_maps: BpfMapsData, meter: Meter) -> Result<(), a
 
     let cpu_idle_metrics = {
         let metrics = Arc::clone(&metrics);
+        let service_cache = Arc::clone(&cache);
         let mut array_buffers = cpu_idle_perf_buffer;
         let mut buffers = cpu_idle_buffers;
         tokio::spawn(async move {
-            read_perf_buffer(array_buffers, buffers, Consumer::CpuIdle, Some(metrics)).await;
+            read_perf_buffer(
+                array_buffers,
+                buffers,
+                Consumer::CpuIdle,
+                Some(metrics),
+                Some(service_cache),
+            )
+            .await;
         })
     };
 
     let mem_alloc_metrics = {
         let metrics = Arc::clone(&metrics);
+        let service_cache = Arc::clone(&cache);
         let mut array_buffers = mem_alloc_perf_buffer;
         let mut buffers = mem_alloc_buffers;
         tokio::spawn(async move {
-            read_perf_buffer(array_buffers, buffers, Consumer::MemAlloc, Some(metrics)).await;
+            read_perf_buffer(
+                array_buffers,
+                buffers,
+                Consumer::MemAlloc,
+                Some(metrics),
+                Some(service_cache),
+            )
+            .await;
         })
     };
 
     let sched_stat_wait_metrics = {
         let metrics = Arc::clone(&metrics);
+        let service_cache = Arc::clone(&cache);
+
         let mut array_buffers = sched_stat_wait_perf_buffer;
         let mut buffers = sched_stat_wait_buffers;
         tokio::spawn(async move {
@@ -222,6 +269,7 @@ pub async fn event_listener(bpf_maps: BpfMapsData, meter: Meter) -> Result<(), a
                 buffers,
                 Consumer::SchedStatWait,
                 Some(metrics),
+                Some(service_cache),
             )
             .await;
         })
@@ -229,6 +277,7 @@ pub async fn event_listener(bpf_maps: BpfMapsData, meter: Meter) -> Result<(), a
 
     let sched_stat_runtime_metrics = {
         let metrics = Arc::clone(&metrics);
+        let service_cache = Arc::clone(&cache);
         let mut array_buffers = sched_stat_runtime_perf_buffer;
         let mut buffers = sched_stat_runtime_buffers;
         tokio::spawn(async move {
@@ -237,6 +286,7 @@ pub async fn event_listener(bpf_maps: BpfMapsData, meter: Meter) -> Result<(), a
                 buffers,
                 Consumer::SchedStatRuntime,
                 Some(metrics),
+                Some(service_cache),
             )
             .await;
         })
@@ -244,16 +294,30 @@ pub async fn event_listener(bpf_maps: BpfMapsData, meter: Meter) -> Result<(), a
 
     let ssl_events_metrics = {
         let metrics = Arc::clone(&metrics);
+        let service_cache = Arc::clone(&cache);
         let mut array_buffers = ssl_events_perf_buffer;
         let mut buffers = ssl_events_buffers;
         tokio::spawn(async move {
-            read_perf_buffer(array_buffers, buffers, Consumer::SslEvents, Some(metrics)).await;
+            read_perf_buffer(
+                array_buffers,
+                buffers,
+                Consumer::SslEvents,
+                Some(metrics),
+                Some(service_cache),
+            )
+            .await;
         })
     };
 
     info!("Event listeners started, entering main loop...");
 
     tokio::select! {
+        result = cache_handle => {
+            if let Err(e) = result {
+                error!("Cache handle task failed: {:?}", e);
+            }
+        }
+
         result = net_metrics_handle => {
             if let Err(e) = result {
                 error!("Network metrics task failed: {:?}", e);

--- a/core/src/components/metrics/src/helpers.rs
+++ b/core/src/components/metrics/src/helpers.rs
@@ -61,6 +61,27 @@ pub fn resolve_libssl_path() -> anyhow::Result<Option<String>> {
     Ok(None)
 }
 
+/// Initialise the shared OpenTelemetry metrics handle and the Docker/K8s
+/// service cache used by every perf-buffer consumer.
+pub async fn init_metrics_and_cache(
+    meter: &Meter,
+) -> Result<
+    (
+        Arc<Metrics>,
+        Arc<tokio::sync::RwLock<ServiceCache>>,
+    ),
+    anyhow::Error,
+> {
+    let metrics = Arc::new(Metrics::new(meter));
+
+    let mut cache_obj = ServiceCache { service_map: None };
+    cache_obj.init();
+    cache_obj.populate_map_with_pod_info().await?;
+    let cache = Arc::new(tokio::sync::RwLock::new(cache_obj));
+
+    Ok((metrics, cache))
+}
+
 /// Listen for eBPF perf-buffer events and record OpenTelemetry metrics.
 ///
 /// This function bridges the eBPF perf-buffer layer with the OpenTelemetry
@@ -147,11 +168,7 @@ pub async fn event_listener(bpf_maps: BpfMapsData, meter: Meter) -> Result<(), a
     let sched_stat_runtime_buffers = BufferSize::SchedStatRuntime.set_buffer();
     let ssl_events_buffers = BufferSize::SslEvents.set_buffer();
 
-    let metrics = Arc::new(Metrics::new(&meter));
-    let mut cache_obj = ServiceCache { service_map: None };
-    cache_obj.init(); //init cache
-    cache_obj.populate_map_with_pod_info().await?; // populate cache with a first scan of the services 
-    let cache = Arc::new(tokio::sync::RwLock::new(cache_obj));
+    let (metrics, cache) = init_metrics_and_cache(&meter).await?;
 
     info!("Starting event listener tasks...");
 

--- a/core/src/components/metrics_tracer/src/cpu.rs
+++ b/core/src/components/metrics_tracer/src/cpu.rs
@@ -58,28 +58,30 @@ pub fn per_cpu_bytes_alloc(ctx: &TracePointContext) -> Result<((u32, u32, [u8; 1
     Ok((bytes_alloc, tgid, command))
 }
 
-pub fn sched_stat_wait(ctx: &TracePointContext) -> Result<((u32, u64, [u8; 16])), i64> {
+pub fn sched_stat_wait(ctx: &TracePointContext) -> Result<((u32, u64, [u8; 16], u64)), i64> {
     let delay_offset = 16;
 
     //let tgid: u32 = unsafe { ctx.read_at(tgid_offset) }?;
     let pid_tgid: u64 = bpf_get_current_pid_tgid();
     let tgid: u32 = (pid_tgid >> 32) as u32;
+    let cgroup_id: u64 = unsafe { bpf_get_current_cgroup_id() };
 
     let delay = unsafe { ctx.read_at(delay_offset) }?;
     let command = ctx.command()?;
 
-    Ok((tgid, delay, command))
+    Ok((tgid, delay, command, cgroup_id))
 }
 
-pub fn sched_stat_runtime(ctx: &TracePointContext) -> Result<((u32, u64, [u8; 16])), i64> {
+pub fn sched_stat_runtime(ctx: &TracePointContext) -> Result<((u32, u64, [u8; 16], u64)), i64> {
     let runtime_offset = 16;
 
     //let tgid: u32 = unsafe { ctx.read_at(tgid_offset) }?;
     let pid_tgid: u64 = bpf_get_current_pid_tgid();
     let tgid: u32 = (pid_tgid >> 32) as u32;
+    let cgroup_id: u64 = unsafe { bpf_get_current_cgroup_id() };
 
     let runtime = unsafe { ctx.read_at(runtime_offset) }?;
     let command = ctx.command()?;
 
-    Ok((tgid, runtime, command))
+    Ok((tgid, runtime, command, cgroup_id))
 }

--- a/core/src/components/metrics_tracer/src/data_structures.rs
+++ b/core/src/components/metrics_tracer/src/data_structures.rs
@@ -17,6 +17,7 @@ pub struct PacketLossMetrics {
     pub sk_receive_buffer_size: i32, // Offset 244
     pub sk_ack_backlog: u32,         // Offset 604
     pub sk_drops: i32,               // Offset 136
+    pub cgroup_id: u64,
 }
 
 #[repr(C, packed)]
@@ -25,6 +26,7 @@ pub struct TimeStampStartInfo {
     pub comm: [u8; TASK_COMM_LEN],
     pub ts_ns: u64,
     pub tgid: u32,
+    pub cgroup_id: u64,
 }
 
 /// Event we send to userspace when latency is computed
@@ -43,6 +45,7 @@ pub struct TimeStampEvent {
     pub daddr_v4: u32,
     pub saddr_v6: [u32; 4],
     pub daddr_v6: [u32; 4],
+    pub cgroup_id: u64,
 }
 
 #[repr(C, packed)]
@@ -62,6 +65,7 @@ pub struct MemAlloc {
     pub(crate) length: u64,
     pub(crate) addr: u64,
     pub(crate) command: [u8; 16],
+    pub(crate) cgroup_id: u64,
 }
 
 #[repr(C, packed)]
@@ -70,6 +74,7 @@ pub struct SchedStatWait {
     pub(crate) tgid: u32,
     pub(crate) delay: u64,
     pub(crate) command: [u8; 16],
+    pub(crate) cgroup_id: u64,
 }
 
 #[repr(C, packed)]
@@ -78,6 +83,7 @@ pub struct SchedStatRuntime {
     pub(crate) tgid: u32,
     pub(crate) runtime: u64,
     pub(crate) command: [u8; 16],
+    pub(crate) cgroup_id: u64,
 }
 
 #[repr(C, packed)]
@@ -96,6 +102,7 @@ pub struct SslEvent {
     pub direction: u8,  // 0 = read, 1 = write
     pub size: i32,      // return value (bytes transferred or <0 on error)
     pub requested: i32, // num argument passed to SSL_read/SSL_write
+    pub cgroup_id: u64,
 }
 
 // Map: connect-start timestamp by socket pointer

--- a/core/src/components/metrics_tracer/src/main.rs
+++ b/core/src/components/metrics_tracer/src/main.rs
@@ -127,13 +127,14 @@ fn trace_enter_mmap(ctx: TracePointContext) -> u32 {
 }
 
 fn trace_memory_allocation(ctx: &TracePointContext) -> Result<(), i64> {
-    let (tgid, addr, length, command) = enter_mmap(ctx)?;
+    let (tgid, addr, length, command, cgroup_id) = enter_mmap(ctx)?;
 
     let memory_alloc_metrics = MemAlloc {
         tgid,
         addr,
         length,
         command,
+        cgroup_id,
     };
 
     unsafe { MEM_ALLOC.output(ctx, &memory_alloc_metrics, 0) };
@@ -150,12 +151,13 @@ fn trace_sched_stat_wait(ctx: TracePointContext) -> u32 {
 }
 
 fn sched_stat_wait_tracer(ctx: &TracePointContext) -> Result<(), i64> {
-    let (tgid, delay, command) = sched_stat_wait(ctx)?;
+    let (tgid, delay, command, cgroup_id) = sched_stat_wait(ctx)?;
 
     let sched_stat_wait_data = SchedStatWait {
         tgid,
         delay,
         command,
+        cgroup_id,
     };
 
     unsafe { SCHED_STAT_WAIT.output(ctx, &sched_stat_wait_data, 0) };
@@ -172,12 +174,13 @@ fn trace_sched_stat_runtime(ctx: TracePointContext) -> u32 {
 }
 
 fn sched_stat_runtime_tracer(ctx: &TracePointContext) -> Result<(), i64> {
-    let (tgid, runtime, command) = sched_stat_runtime(ctx)?;
+    let (tgid, runtime, command, cgroup_id) = sched_stat_runtime(ctx)?;
 
     let sched_stat_runtime_data = SchedStatRuntime {
         tgid,
         runtime,
         command,
+        cgroup_id,
     };
 
     unsafe { SCHED_STAT_RUNTIME.output(ctx, &sched_stat_runtime_data, 0) };

--- a/core/src/components/metrics_tracer/src/memory.rs
+++ b/core/src/components/metrics_tracer/src/memory.rs
@@ -1,7 +1,11 @@
-use aya_ebpf::{EbpfContext, helpers::bpf_get_current_pid_tgid, programs::TracePointContext};
+use aya_ebpf::{
+    EbpfContext,
+    helpers::{bpf_get_current_cgroup_id, bpf_get_current_pid_tgid},
+    programs::TracePointContext,
+};
 
 /// Read the fields of the `syscalls:sys_enter_mmap` tracepoint.
-pub fn enter_mmap(ctx: &TracePointContext) -> Result<((u32, u64, u64, [u8; 16])), i64> {
+pub fn enter_mmap(ctx: &TracePointContext) -> Result<((u32, u64, u64, [u8; 16], u64)), i64> {
     // For syscall tracepoints `common_pid` is the TGID of the calling thread.
     let tgid_offset = 4;
     let addr_offset = 16;
@@ -10,9 +14,10 @@ pub fn enter_mmap(ctx: &TracePointContext) -> Result<((u32, u64, u64, [u8; 16]))
     //let tgid: u32 = unsafe { ctx.read_at(tgid_offset) }?;
     let pid_tgid: u64 = bpf_get_current_pid_tgid();
     let tgid: u32 = (pid_tgid >> 32) as u32;
+    let cgroup_id: u64 = unsafe { bpf_get_current_cgroup_id() };
     let addr: u64 = unsafe { ctx.read_at(addr_offset) }?;
     let len: u64 = unsafe { ctx.read_at(len_offset) }?;
     let command = ctx.command()?;
 
-    Ok((tgid, addr, len, command))
+    Ok((tgid, addr, len, command, cgroup_id))
 }

--- a/core/src/components/metrics_tracer/src/network.rs
+++ b/core/src/components/metrics_tracer/src/network.rs
@@ -5,7 +5,7 @@ use crate::data_structures::{
 };
 use aya_ebpf::EbpfContext;
 use aya_ebpf::helpers::bpf_get_current_pid_tgid;
-use aya_ebpf::helpers::generated::{bpf_ktime_get_ns, bpf_perf_event_output};
+use aya_ebpf::helpers::generated::{bpf_get_current_cgroup_id, bpf_ktime_get_ns, bpf_perf_event_output};
 use aya_ebpf::helpers::{
     bpf_get_current_comm, bpf_probe_read_kernel, bpf_probe_read_kernel_str_bytes,
 };
@@ -27,6 +27,7 @@ pub fn detect_packet_loss(ctx: &ProbeContext) -> Result<PacketLossMetrics, i64> 
     }
 
     let tgid = (unsafe { bpf_get_current_pid_tgid() } >> 32) as u32;
+    let cgroup_id: u64 = unsafe { bpf_get_current_cgroup_id() };
     let comm = unsafe { bpf_get_current_comm() }.map_err(|_| 1i64)?;
     let ts_us: u64 = unsafe { bpf_ktime_get_ns() } / 1_000;
     let sk_err_offset = 284;
@@ -76,6 +77,7 @@ pub fn detect_packet_loss(ctx: &ProbeContext) -> Result<PacketLossMetrics, i64> 
         sk_receive_buffer_size: sk_receive_buffer_size,
         sk_ack_backlog: sk_ack_backlog,
         sk_drops: sk_drops,
+        cgroup_id,
     };
 
     Ok(packet_loss_metrics)
@@ -88,10 +90,12 @@ pub fn on_connect(ctx: ProbeContext) -> Result<(), i64> {
     }
 
     let tgid = (unsafe { bpf_get_current_pid_tgid() } >> 32) as u32;
+    let cgroup_id: u64 = unsafe { bpf_get_current_cgroup_id() };
     let mut start = TimeStampStartInfo {
         comm: [0; TASK_COMM_LEN],
         ts_ns: unsafe { bpf_ktime_get_ns() },
         tgid,
+        cgroup_id,
     };
     unsafe {
         let comm_result = bpf_get_current_comm();
@@ -162,6 +166,7 @@ pub fn on_rcv_state_process(ctx: ProbeContext) -> Result<(), i64> {
         daddr_v4: 0,
         saddr_v6: [0; 4],
         daddr_v6: [0; 4],
+        cgroup_id: start.cgroup_id,
     };
 
     // family, ports

--- a/core/src/components/metrics_tracer/src/ssl.rs
+++ b/core/src/components/metrics_tracer/src/ssl.rs
@@ -1,7 +1,7 @@
 // observe L5 and L6 connections
 
 use crate::data_structures::{SSL_CTX_MAP, SSL_EVENTS, SslEvent};
-use aya_ebpf::helpers::{bpf_get_current_comm, bpf_get_current_pid_tgid, bpf_ktime_get_ns};
+use aya_ebpf::helpers::{bpf_get_current_comm, bpf_get_current_cgroup_id, bpf_get_current_pid_tgid, bpf_ktime_get_ns};
 use aya_ebpf::programs::{ProbeContext, RetProbeContext};
 
 /// store requested bytes keyed by pid_tgid
@@ -25,6 +25,7 @@ pub fn try_ssl_event_end(ctx: &RetProbeContext, direction: u8) -> Result<(), i64
     let size = ctx.ret::<i32>();
     let pid_tgid = unsafe { bpf_get_current_pid_tgid() }; // extracts pid and tgid
     let tgid = (pid_tgid >> 32) as u32; // read only tgid 
+    let cgroup_id: u64 = unsafe { bpf_get_current_cgroup_id() };
 
     let map_ptr = unsafe { &raw mut SSL_CTX_MAP };
     let requested = unsafe { (*map_ptr).get(&pid_tgid) }.copied().ok_or(1i64)?;
@@ -39,6 +40,7 @@ pub fn try_ssl_event_end(ctx: &RetProbeContext, direction: u8) -> Result<(), i64
         direction,
         size,
         requested,
+        cgroup_id,
     };
 
     unsafe {

--- a/core/src/testing/metrics.yaml
+++ b/core/src/testing/metrics.yaml
@@ -19,7 +19,7 @@ spec:
       hostNetwork: true
       containers:
         - name: metrics
-          image: ghcr.io/cortexflow/metrics:latest
+          image: lorenzotettamanti/cortexflow-metrics:0.1.1-1
           command: ["/bin/bash", "-c"]
           args:
             - |

--- a/core/src/testing/metrics.yaml
+++ b/core/src/testing/metrics.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: cortexflow-metrics
+  name: cortexflow-metrics-cache-5s
   namespace: cortexflow
   labels:
     app: cortexflow-metrics
@@ -19,7 +19,7 @@ spec:
       hostNetwork: true
       containers:
         - name: metrics
-          image: lorenzotettamanti/cortexflow-metrics:0.1.1-1
+          image: lorenzotettamanti/cortexflow-metrics:0.1.1-cache-5s-update-6
           command: ["/bin/bash", "-c"]
           args:
             - |
@@ -45,6 +45,8 @@ spec:
             value: grpc
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.namespace=cortexflow,service.version=0.1.5
+          - name: CF_DEBUG_LEVEL
+            value: debug
           volumeMounts:
             - name: bpf
               mountPath: /sys/fs/bpf
@@ -59,6 +61,9 @@ spec:
             - name: tracefs
               mountPath: /sys/kernel/debug
               readOnly: false
+            - name: cgroup
+              mountPath: /host/sys/fs/cgroup
+              readOnly: true
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
@@ -109,9 +114,11 @@ spec:
           hostPath:
             path: /lib/modules
             type: Directory
-
         - name: tracefs
           hostPath:
             path: /sys/kernel/debug
             type: Directory
-
+        - name: cgroup
+          hostPath:
+            path: /sys/fs/cgroup
+            type: Directory


### PR DESCRIPTION
# Changes
- Added CF_DEBUG_LEVEL as environment variable in logger.rs to let users customize the logging level without rebuilding the image
- Added service cache and increased the read_perf_buffer drain time to 5s to prevent the CPU overload
- Fixed cargo.toml
- updated metrics.yaml image
- Updated metadata enrichment to mutually exclude docker and Kubernetes environements
- Updated Dockerfiles and build-conntracker script
- Fixed cfg attribute in consumer.rs (std::sync::Arc import)

## Tests
- [x] All checks passed
- [x] Works with docker and kubernetes